### PR TITLE
Switch endpoint querier to use port 3333 instead of standard 8443

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,23 +104,42 @@ The data collected by the endpoint querier can then be collected by Prometheus, 
 
 ## Starting All Services Using docker-compose
 All of the required services to run the Lantern back end are contained in the docker-compose file.
+
 **Notice:** Before running `docker-compose up` make sure that you have created a hidden file named `.env` containing the environment variables specified in the `env.sample` file located alongside `docker-compose.yml`
+
+To run all of the dockerized services for a development environment, run
+
 ```bash
 docker-compose up
 ```
-This will start an endpoint querier, Prometheus, Postgres, Prometheus Postgres storage adapter, Grafana, Rabbitmq and will setup the networking between the related services. 
-To start all of the services in the background run:
+
+This will start endpoint querier, Prometheus, Postgres, Prometheus Postgres storage adapter, Grafana, and Rabbitmq; will setup the networking between the related services; and will publish ports.
+
+To run all of the dockerized services for a production environment, run
+
 ```bash
-docker-compose up -d
+docker-compose -f docker-compose.yml up
 ```
+
+This will start endpoint querier, Prometheus, Postgres, Prometheus Postgres storage adapter, Grafana, and Rabbitmq; will setup the networking between the related services; and will only publish port 3000 to port 80 for Grafana.
+
+To start all of the services in the background, add `-d` to your `docker-compose up` command.
+
+To stop everything and remove the containers and network, run:
+```bash
+docker-compose down
+```
+
 To stop everything and keep the containers/volumes run:
 ```bash
 docker-compose stop
 ```
+
 If you stopped the containers and wish to restart them you can run:
 ```bash
 docker-compose start
 ```
+
 ## Starting Prometheus via Docker Container
 You'll still need a prometheus.yml configuration file for this, see https://github.com/prometheus/prometheus/blob/master/documentation/examples/prometheus.yml make sure that the configuration has [the FHIR Querier as a Target](#adding-the-fhir-querier-service-as-a-target)
 ```bash

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The FHIR Endpoint Querier reads the following environment variables:
 
 * **LANTERN_ENDPTQRY_PORT**: The port where the metrics gathered from the FHIR endpoints will be hosted.
 
-  Default value: 8443
+  Default value: 3333
 
 * **LANTERN_ENDPTQRY_LOGFILE**: The location of the logfile for log messages
 
@@ -97,7 +97,7 @@ docker build -t endpoint_querier .
 ```
 To start the Docker container that you just bult run:
 ```bash
-docker run -p 8443:8443 -it endpoint_querier
+docker run -p 3333:3333 -it endpoint_querier
 ```
 # Additional Services
 The data collected by the endpoint querier can then be collected by Prometheus, which can be written to a Postgres database using the Prometheus Postgres storage adapter. This data can ultimately be viewed in Grafana. Below is information about how to start these additional services.

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,11 @@
+version: '3'
+
+services:
+  pg_prometheus:
+    ports:
+      - "5432:5432"
+
+  lantern-mq:
+    ports:
+      - "15672:15672"
+      - "5672:5672"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,6 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     command:
       -csynchronous_commit=off
-    ports:
-      - "5432:5432"
 
   prometheus_postgresql_adapter:
     container_name: prometheus_postgres_adapter
@@ -47,7 +45,7 @@ services:
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_SECURITY_ALLOW_EMBEDDING=true
     ports:
-      - "3000:3000"
+      - "80:3000"
   
   lantern-mq:
     container_name: lantern-mq

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,6 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     command:
       -csynchronous_commit=off
-    ports:
-      - "5432:5432"
 
   prometheus_postgresql_adapter:
     container_name: prometheus_postgres_adapter
@@ -52,9 +50,6 @@ services:
   lantern-mq:
     container_name: lantern-mq
     image: rabbitmq:3-management
-    ports:
-      - "15672:15672"
-      - "5672:5672"
 
 volumes:
   pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     command:
       -csynchronous_commit=off
+    ports:
+      - "5432:5432"
 
   prometheus_postgresql_adapter:
     container_name: prometheus_postgres_adapter

--- a/endpoints/main.go
+++ b/endpoints/main.go
@@ -151,7 +151,7 @@ func setupConfig() {
 	err = viper.BindEnv("logfile")
 	failOnError(err)
 
-	viper.SetDefault("port", 8443)
+	viper.SetDefault("port", 3333)
 	viper.SetDefault("logfile", "endpointQuerierLog.json")
 }
 

--- a/endpoints/vendor/github.com/onc-healthit/lantern-back-end/endpoints/main.go
+++ b/endpoints/vendor/github.com/onc-healthit/lantern-back-end/endpoints/main.go
@@ -155,7 +155,7 @@ func setupConfig() {
 		panic(err.Error())
 	}
 
-	viper.SetDefault("port", 8443)
+	viper.SetDefault("port", 3333)
 	viper.SetDefault("logfile", "endpointQuerierLog.json")
 }
 

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -11,7 +11,7 @@ scrape_configs:
     # metrics_path defaults to '/metrics'
     # scheme defaults to 'http'.
     static_configs:
-    - targets: ['endpoint_querier_1:8443']
+    - targets: ['endpoint_querier_1:3333']
 
 remote_write:
     - url: "http://prometheus_postgres_adapter:9201/write"


### PR DESCRIPTION
8443 is an open port on our EC2 instance, switch endpoint querier port to be 3333. Stop the publishing of the database port since it is only being accessed on the docker network.

Pull requests into this repository require the following checks to be completed by the submitter and reviewers.

**Submitter:**
- [x] Administrative tasks are complete.
  - This pull request describes why these changes were made.
  - The JIRA ticket links to this PR.
  - The JIRA ticket for this PR is:  https://oncprojectracking.healthit.gov/support/browse/LANTERN-43
  - vendor/ directories have been updated
    - New dependencies have been added
    - Local dependencies have been updated
- [x] Tests are complete.
  - Tests are included and test edge cases.
  - Tests have been run locally and pass.
- [x] Code review has been performed.
  - Code diff has been done and checked to ensure only expected code is being committed.
  - A linter for the language has been run.

**Primary Reviewer:** @edeyoung 

- [x] Code works.
  - Code has been run locally and the basic functionality affected by the PR has been checked.
  - Edge cases have been checked to ensure behavior is as expected.
- [x] Code review has been performed.
  - Code is maintainable, reusable, efficient, and correct.
  - Code accomplishes the tasks purpose.
  - Code follows style guidance appropriate for the language, including passing linter checks.
  - Code is well commented (which does not mean verbosely commented).
  - vendor/ directories have been updated
    - New dependencies have been added
    - Local dependencies have been updated
- [x] Tests are complete. Tested by starting using `docker-compose up` and checking that i could run tests for the db and for the queue. Then tested by using `docker-compose -f docker-compose.yml up` and checked that the tests failed, that i could access grafana on port 80, and that grafana was getting data after hooking up to postgres.
  - Tests are included and test edge cases.
  - Tests have been run locally and pass.

**Secondary Reviewer:**

- [x] Code works.
  - Code has been run locally and the basic functionality affected by the PR has been checked.
  - Edge cases have been checked to ensure behavior is as expected.
- [x] Code review has been performed.
  - Code accomplishes the tasks purpose.
- [x] Tests are complete.
  - Tests have been run locally and pass.

**Merger:**

Prior to merging, ensure that all checks have been completed. Delete the branch after the merge is complete.