### PR TITLE
Shiny server load test

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,28 @@ brew install golangci/tap/golangci-lint
 ```
 More information about golangci-lint can be found [here](https://github.com/golangci/golangci-lint)
 
+## Running Shiny Load Test
+To run a load test, install shiny load test and shiny cannon [here](https://rstudio.github.io/shinyloadtest/)
+
+Record a user session in the R console
+```
+shinyloadtest::record_session('http://localhost:3838/', output_file = '/path/to/output/recording.log')
+```
+This will open a browser with the shiny dashboard loaded. Interact with the app and close the tab/browser to end session recording.
+
+Run a load test in the terminal using the recorded session
+```
+shinycannon <path/to/recording.log> http://localhost:3838/ --workers 5 --loaded-duration-minutes 2 --output-dir /Path/for/output/run
+```
+The workers are number of concurrent users to simulate. The loaded duration minutes is how long to run the test for once it warms up (reaches the specified number of workers). A worker will repeat the session as many times as possible within the loaded duration. 
+
+Analyze the results
+```
+df <- shinyloadtest::load_runs("5 workers" = "/path/to/test/run")
+shinyloadtest::shinyloadtest_report(df, "/path/for/output/report.html")
+```
+This will load the results of the test run into a dataframe then generate a report. 
+
 ## GoMod
 If you make changes in one package and would like to use those changes in another package that depends on the first package that you change, commit your code and run `make update_mods branch=<your_working_branch>` This is especially relevant when running your new code in docker images built for the e2e, capabilityquerier and networkstatsquerier branches as the go.mod files are what will be used to determine which versions of the packages should be checked out when the docker images are built. Your final commit in a PR should be the go.mod and go.sum updates that occur as a result of running `make update_mods branch=<your_working_branch>`
 

--- a/shinydashboard/Dockerfile
+++ b/shinydashboard/Dockerfile
@@ -16,6 +16,7 @@ RUN R -e "remotes::install_github('rstudio/renv@${RENV_VERSION}')"
 
 # Environment variables are passed to R via .Renviron file the container
 RUN env | grep LANTERN > /home/shiny/.Renviron && chown shiny.shiny /home/shiny/.Renviron
+COPY shiny-server.conf  /etc/shiny-server/shiny-server.conf
 
 WORKDIR /.
 COPY renv.lock renv.lock

--- a/shinydashboard/shiny-server.conf
+++ b/shinydashboard/shiny-server.conf
@@ -1,0 +1,21 @@
+# Define the user we should use when spawning R Shiny processes
+run_as shiny;
+
+# Define a top-level server which will listen on a port
+server {
+  listen 3838;
+
+  # Define the location available at the base URL
+  location / {
+    # Run this location in 'site_dir' mode, which hosts the entire directory
+    # tree at '/srv/shiny-server'
+    site_dir /srv/shiny-server;
+    
+    # Define where we should put the log files for this location
+    log_dir /var/log/shiny-server;
+    
+
+    # Allow 300 concurrent users 
+    simple_scheduler 300;
+  }
+}


### PR DESCRIPTION

Installing Shiny load test:
https://rstudio.github.io/shinyloadtest/

1.) To record a session and have the log output directed to a specific directory
run this command in R console. 
`shinyloadtest::record_session('http://localhost:3838/', output_file = '/../../../lantern/recording.log')`
This will open a browser with the shiny dashboard loaded. Interact with the site like a normal user then close the browser/tab when finish recording session. 

2.) Run a load test run command in terminal
`shinycannon <path/to/recording.log> http://localhost:3838/ --workers 5 --loaded-duration-minutes 2 --output-dir /Path/for/output/run1`

The workers are the number of concurrent users to simulate. Loaded duration minutes is how long to run the test load with concurrent users. 

3.) Analyze results 
run this command in R console 
Loads the results of test run into dataframe
`df <- shinyloadtest::load_runs("5 workers" = "./run1")`

4.) Generate a report
`shinyloadtest::shinyloadtest_report(df, "run1.html")`


Results
I ran several test sessions with 10, 25, 50, 75, 80, 90, 100, 110, and 125 workers - each one for a duration of 5 minutes and the later ones with 10 minutes as well. At 75 workers, none of the test fail but app becomes significantly slower. In the report.html file the session duration page has a chart that shows how long it took each session to run relative to each other. The vertical red line is how long the original recorded session takes (207s). The length of each session is shown as a horizontal bar and is sorted by shortest to longest duration. Ideally they should end around the same time as the red line. In the report for 75 workers majority of the sessions took twice as long. At 110 concurrent users the test starts failing and at 125 users all of then fail. Many of the test runs per session do not complete within the 5 minutes. When I increase the duration to 10 minutes, there are more failures and message not received errors. The event waterfall tab shows the order of events. Ideally all the lines should be parallel to each other which indicate consistent behavior. In the test runs, the lines start to jut out horizontally when it makes POST request. The event concurrency tab shows the events with the largest slope when all test runs are fitted to a line. A strong linear trend with increasing concurrency shows that as the number of users increases, waiting time will increase. The POST events have the strongest trend. 

I attached the log files and report in the jira ticket. 




Pull requests into this repository require the following checks to be completed by the submitter and reviewers.

**Submitter:**
- [x] Administrative tasks are complete.
  - This pull request describes why these changes were made.
  - The JIRA ticket links to this PR.
  - The JIRA ticket for this PR is: https://oncprojectracking.healthit.gov/support/browse/LANTERN-210
- [x] Tests are complete. N/A
  - Tests are included and test edge cases.
  - Tests have been run locally and pass.
- [x] Code review has been performed.
  - Code diff has been done and checked to ensure only expected code is being committed.
  - A linter for the language has been run.

**Primary Reviewer:**

- [x] Code works.
  - Code has been run locally and the basic functionality affected by the PR has been checked.
  - Edge cases have been checked to ensure behavior is as expected.
- [x] Code review has been performed.
  - Code is maintainable, reusable, efficient, and correct.
  - Code accomplishes the tasks purpose.
  - Code follows style guidance appropriate for the language, including passing linter checks.
  - Code is well commented (which does not mean verbosely commented).
- [x] Tests are complete.
  - Tests are included and test edge cases.
  - Tests have been run locally and pass.

**Secondary Reviewer:**

- [x] Code works.
  - Code has been run locally and the basic functionality affected by the PR has been checked.
  - Edge cases have been checked to ensure behavior is as expected.
- [x] Code review has been performed.
  - Code accomplishes the tasks purpose.
- [x] Tests are complete.
  - Tests have been run locally and pass.

**Merger:**

Prior to merging, ensure that all checks have been completed. Delete the branch after the merge
is complete.

Create a new branch `<branch name>_gomodupdate`. Run `make update_mods` to update the `go.mod`
and `go.sum` files to point to master. Create a PR. Require one sanity check reviewer.
