### PR TITLE
Go workers always running 

### DIFF
--- a/capabilityquerier/README.md
+++ b/capabilityquerier/README.md
@@ -78,3 +78,13 @@ go get ./... # You may have to set environment variable GO111MODULE=on
 go mod download
 go run cmd/main.go
 ```
+
+## Scaling
+
+To scale out the capability querier service edit the docker-compose.yml and docker-compose.override.yml file to include additional capability querier services. 
+```
+capability_querier_2:
+  ...
+``` 
+
+Each instance of the capability querier will query endpoints from the same endpoints-to-capability queue in a round robin style.

--- a/endpointmanager/pkg/sendendpoints/sendendpoints.go
+++ b/endpointmanager/pkg/sendendpoints/sendendpoints.go
@@ -32,11 +32,6 @@ func GetEnptsAndSend(
 			errs <- err
 		}
 
-		err = accessqueue.SendToQueue(ctx, "start", mq, channelID, qName)
-		if err != nil {
-			errs <- err
-		}
-
 		// Shuffle Endpoints So that We Are Not Querying As Rapidly
 		rand.Shuffle(len(listOfEndpoints), func(i, j int) {
 			listOfEndpoints[i], listOfEndpoints[j] = listOfEndpoints[j], listOfEndpoints[i]
@@ -52,11 +47,6 @@ func GetEnptsAndSend(
 			if err != nil {
 				errs <- err
 			}
-		}
-
-		err = accessqueue.SendToQueue(ctx, "stop", mq, channelID, qName)
-		if err != nil {
-			errs <- err
 		}
 
 		log.Infof("Waiting %d minutes", qInterval)

--- a/endpointmanager/pkg/sendendpoints/sendenpt_integration_test.go
+++ b/endpointmanager/pkg/sendendpoints/sendenpt_integration_test.go
@@ -98,8 +98,8 @@ func Test_GetEnptsAndSend(t *testing.T) {
 	time.Sleep(10 * time.Second)
 	count, err := aq.QueueCount(queueName, channel)
 	th.Assert(t, err == nil, err)
-	// Expect 5 messages: start meesage, 3 endpoints, and stop message
-	th.Assert(t, count == 5, fmt.Sprintf("expected there to be 5 messages in the queue, instead got %d", count))
+	// Expect 3 messages: 3 endpoints
+	th.Assert(t, count == 3, fmt.Sprintf("expected there to be 3 messages in the queue, instead got %d", count))
 	wg.Done()
 }
 


### PR DESCRIPTION
Endpointmanager does not send a start or stop message anymore.
Go workers start when capability querier is running. They are always running and ready to consume messages. 

To test:
Edit the docker-compose.yml  and docker-compose.override.yml file to include a second capabilityQuerier

`make run`
`make populatedb`
run the sendendpoints 
Verify that the docker container logs shows both capability querier services making the GET request to the endpoints


Pull requests into this repository require the following checks to be completed by the submitter and reviewers.

**Submitter:**
- [x] Administrative tasks are complete.
  - This pull request describes why these changes were made.
  - The JIRA ticket links to this PR.
  - The JIRA ticket for this PR is: https://oncprojectracking.healthit.gov/support/browse/LANTERN-196
- [x] Tests are complete.
  - Tests are included and test edge cases.
  - Tests have been run locally and pass.
- [x] Code review has been performed.
  - Code diff has been done and checked to ensure only expected code is being committed.
  - A linter for the language has been run.

**Primary Reviewer:**

- [x] Code works.
  - Code has been run locally and the basic functionality affected by the PR has been checked.
  - Edge cases have been checked to ensure behavior is as expected.
- [x] Code review has been performed.
  - Code is maintainable, reusable, efficient, and correct.
  - Code accomplishes the tasks purpose.
  - Code follows style guidance appropriate for the language, including passing linter checks.
  - Code is well commented (which does not mean verbosely commented).
- [x] Tests are complete.
  - Tests are included and test edge cases.
  - Tests have been run locally and pass.

**Secondary Reviewer:**

- [x] Code works.
  - Code has been run locally and the basic functionality affected by the PR has been checked.
  - Edge cases have been checked to ensure behavior is as expected.
- [x] Code review has been performed.
  - Code accomplishes the tasks purpose.
- [x] Tests are complete.
  - Tests have been run locally and pass.

**Merger:**

Prior to merging, ensure that all checks have been completed. Delete the branch after the merge
is complete.

Create a new branch `<branch name>_gomodupdate`. Run `make update_mods` to update the `go.mod`
and `go.sum` files to point to master. Create a PR. Require one sanity check reviewer.
