### PR TITLE
Empty Security Table Fix

### DIFF
--- a/shinydashboard/lantern/functions/endpoints.R
+++ b/shinydashboard/lantern/functions/endpoints.R
@@ -303,7 +303,7 @@ get_security_endpoints_tbl <- function(db_connection) {
             f.vendor_id,
             json_array_elements(json_array_elements(capability_statement::json#>'{rest,0,security,service}')->'coding')::json->>'code' as code
           FROM fhir_endpoints_info f,fhir_endpoints e
-          WHERE e.url = f.url) a 
+          WHERE e.url = f.url) a
         LEFT JOIN (SELECT v.name as vendor_name, v.id FROM vendors v) b
         ON a.vendor_id = b.id")) %>%
     collect() %>%

--- a/shinydashboard/lantern/functions/endpoints.R
+++ b/shinydashboard/lantern/functions/endpoints.R
@@ -277,8 +277,8 @@ get_security_endpoints <- function(db_connection) {
           capability_statement->>'fhirVersion' as fhir_version,
           json_array_elements(json_array_elements(capability_statement::json#>'{rest,0,security,service}')->'coding')::json->>'code' as code,
           json_array_elements(capability_statement::json#>'{rest,0,security}' -> 'service')::json ->> 'text' as text
-        FROM fhir_endpoints_info f, vendors v
-        WHERE f.vendor_id = v.id")) %>%
+        FROM fhir_endpoints_info f LEFT JOIN vendors v
+        ON f.vendor_id = v.id")) %>%
     collect() %>%
     tidyr::replace_na(list(vendor_name = "Unknown")) %>%
     tidyr::replace_na(list(fhir_version = "Unknown"))
@@ -289,16 +289,23 @@ get_security_endpoints <- function(db_connection) {
 # for display in table of endpoints, with organization name and URL
 get_security_endpoints_tbl <- function(db_connection) {
   res <- tbl(db_connection,
-    sql("SELECT
-          e.url,
-          e.organization_names,
-          v.name as vendor_name,
-          capability_statement->>'fhirVersion' as fhir_version,
-          f.tls_version,
-          json_array_elements(json_array_elements(capability_statement::json#>'{rest,0,security,service}')->'coding')::json->>'code' as code
-        FROM fhir_endpoints_info f, vendors v, fhir_endpoints e
-        WHERE f.vendor_id = v.id
-        AND e.url = f.url")) %>%
+    sql("SELECT a.url,
+            a.organization_names,
+            b.vendor_name,
+            a.fhir_version,
+            a.tls_version,
+            a.code
+          FROM
+          (SELECT e.url,
+            e.organization_names,
+            capability_statement->>'fhirVersion' as fhir_version,
+            f.tls_version,
+  		      f.vendor_id,
+            json_array_elements(json_array_elements(capability_statement::json#>'{rest,0,security,service}')->'coding')::json->>'code' as code
+        	FROM fhir_endpoints_info f,fhir_endpoints e
+        	WHERE e.url = f.url) a 
+          LEFT JOIN (SELECT v.name as vendor_name, v.id FROM vendors v) b
+			    ON a.vendor_id = b.id")) %>%
     collect() %>%
     tidyr::replace_na(list(vendor_name = "Unknown")) %>%
     tidyr::replace_na(list(fhir_version = "Unknown"))

--- a/shinydashboard/lantern/functions/endpoints.R
+++ b/shinydashboard/lantern/functions/endpoints.R
@@ -295,17 +295,17 @@ get_security_endpoints_tbl <- function(db_connection) {
             a.fhir_version,
             a.tls_version,
             a.code
-          FROM
+        FROM
           (SELECT e.url,
             e.organization_names,
             capability_statement->>'fhirVersion' as fhir_version,
             f.tls_version,
-  		      f.vendor_id,
+            f.vendor_id,
             json_array_elements(json_array_elements(capability_statement::json#>'{rest,0,security,service}')->'coding')::json->>'code' as code
-        	FROM fhir_endpoints_info f,fhir_endpoints e
-        	WHERE e.url = f.url) a 
-          LEFT JOIN (SELECT v.name as vendor_name, v.id FROM vendors v) b
-			    ON a.vendor_id = b.id")) %>%
+          FROM fhir_endpoints_info f,fhir_endpoints e
+          WHERE e.url = f.url) a 
+        LEFT JOIN (SELECT v.name as vendor_name, v.id FROM vendors v) b
+        ON a.vendor_id = b.id")) %>%
     collect() %>%
     tidyr::replace_na(list(vendor_name = "Unknown")) %>%
     tidyr::replace_na(list(fhir_version = "Unknown"))


### PR DESCRIPTION
Changes in this PR:

The security table on the shiny dashboard was showing up empty on staging since the queries used to get the table relied on having a non-empty vendor table. This PR fixes the security queries to work with an empty vendor table

Pull requests into this repository require the following checks to be completed by the submitter and reviewers.

**Submitter:**
- [x] Administrative tasks are complete.
  - This pull request describes why these changes were made.
  - The JIRA ticket links to this PR.
  - The JIRA ticket for this PR is: [LANTERN 305 JIRA Ticket](https://oncprojectracking.healthit.gov/support/browse/LANTERN-305)
- [x] Tests are complete.
  - Tests are included and test edge cases.
  - Tests have been run locally and pass.
- [x] Code review has been performed.
  - Code diff has been done and checked to ensure only expected code is being committed.
  - A linter for the language has been run.

**Primary Reviewer:**

- [x] Code works.
  - Code has been run locally and the basic functionality affected by the PR has been checked.
  - Edge cases have been checked to ensure behavior is as expected.
- [x] Code review has been performed.
  - Code is maintainable, reusable, efficient, and correct.
  - Code accomplishes the tasks purpose.
  - Code follows style guidance appropriate for the language, including passing linter checks.
  - Code is well commented (which does not mean verbosely commented).
- [x] Tests are complete.
  - Tests are included and test edge cases.
  - Tests have been run locally and pass.


**Merger:**

Prior to merging, ensure that all checks have been completed. Delete the branch after the merge
is complete.

Create a new branch `<branch name>_gomodupdate`. Run `make update_mods` to update the `go.mod`
and `go.sum` files to point to master. Create a PR. Require one sanity check reviewer.
