### PR TITLE
Staging discrepancy

### DIFF
--- a/endpointmanager/cmd/endpointpopulator/main.go
+++ b/endpointmanager/cmd/endpointpopulator/main.go
@@ -27,7 +27,7 @@ func main() {
 
 	var channel *amqp.Channel
 
-	capQName := viper.GetString("enptinfo_capquery_qname")
+	capQName := viper.GetString("endptinfo_capquery_qname")
 	qUser := viper.GetString("quser")
 	qPassword := viper.GetString("qpassword")
 	qHost := viper.GetString("qhost")

--- a/endpointmanager/cmd/endpointpopulator/main.go
+++ b/endpointmanager/cmd/endpointpopulator/main.go
@@ -45,7 +45,7 @@ func main() {
 	helpers.FailOnError("", err)
 
 	if count != 0 {
-		log.Fatalf("There are %d messages on the queue. Queue must be empty to run the endpoint populator.", count)
+		log.Fatalf("There are %d messages in the queue. Queue must be empty to run the endpoint populator.", count)
 	}
 
 	if len(os.Args) == 3 {


### PR DESCRIPTION
Pull requests into this repository require the following checks to be completed by the submitter and reviewers.

Changes in this PR:
After updating the production source data, `make populatedb` must be run in order for the updated sources to be loaded and for the old endpoints that are no longer in the updated sources to be removed. However, if `make populatedb` is run while the querier is querying endpoints, this is what could cause discrepancy issues. If `make populatedb` is run while the querier is querying endpoints,  it is possible that a url that is removed by this command was already added to the queue before it was removed. Therefore it will then be queried and added back to the info table after being removed by the removeOldEndpoints function, causing a discrepancy between the fhir_endpoints and fhir_endpoints_info tables. To solve this issue, the endpointpopulator now checks to make sure the endptinfo_capquery is empty before starting, and if it is not empty it gives a warning and fails.

TO TEST:

1. make run
2. Restore a database file or make populatedb
3. docker stop lantern-back-end_capability_querier_1
4. docker restart lantern-back-end_endpoint_manager_1
4. Wait for endpoint manager to queue up some messages
5. make populatedb
8. Endpoint populator should have thrown an error due to messages being in the queue

**Submitter:**
- [x] Administrative tasks are complete.
  - This pull request describes why these changes were made.
  - The JIRA ticket links to this PR.
  - The JIRA ticket for this PR is: [Lantern 331 JIRA Ticket](https://oncprojectracking.healthit.gov/support/browse/LANTERN-331)
- [x] Tests are complete.
  - Tests are included and test edge cases.
  - Tests have been run locally and pass.
- [x] Code review has been performed.
  - Code diff has been done and checked to ensure only expected code is being committed.
  - A linter for the language has been run.

**Primary Reviewer:**

- [x] Code works.
  - Code has been run locally and the basic functionality affected by the PR has been checked.
  - Edge cases have been checked to ensure behavior is as expected.
- [x] Code review has been performed.
  - Code is maintainable, reusable, efficient, and correct.
  - Code accomplishes the tasks purpose.
  - Code follows style guidance appropriate for the language, including passing linter checks.
  - Code is well commented (which does not mean verbosely commented).
- [x] Tests are complete.
  - Tests are included and test edge cases.
  - Tests have been run locally and pass.

**Secondary Reviewer:**

- [ ] Code works.
  - Code has been run locally and the basic functionality affected by the PR has been checked.
  - Edge cases have been checked to ensure behavior is as expected.
- [ ] Code review has been performed.
  - Code accomplishes the tasks purpose.
- [ ] Tests are complete.
  - Tests have been run locally and pass.

**Merger:**

Prior to merging, ensure that all checks have been completed. Delete the branch after the merge
is complete.

Create a new branch `<branch name>_gomodupdate`. Run `make update_mods` to update the `go.mod`
and `go.sum` files to point to master. Create a PR. Require one sanity check reviewer.
