### PR TITLE
Shiny Capability Tab Bug Fixes

### DIFF
--- a/shinydashboard/lantern/server.R
+++ b/shinydashboard/lantern/server.R
@@ -283,16 +283,25 @@ function(input, output, session) { #nolint
       return(NULL)
     }
     else{
+      current_selection(NULL)
       updateSelectizeInput(session, "resources", label = "Click in the box below to add or remove resources:", choices = checkbox_resources(), options = list("plugins" = list("remove_button"), "create" = TRUE, "persist" = FALSE))
     }
   })
 
   observeEvent(input$fhir_version, {
-    updateSelectInput(session, "resources", label = "Click in the box below to add or remove resources:", choices = checkbox_resources(), selected = current_selection())
+    if (is.null(current_selection())) {
+      return(NULL)
+    } else {
+      updateSelectizeInput(session, "resources", label = "Click in the box below to add or remove resources:", choices = checkbox_resources(), selected = current_selection(), options = list("plugins" = list("remove_button"), "create" = TRUE, "persist" = FALSE))
+    }
   })
 
   observeEvent(input$vendor, {
-    updateSelectInput(session, "resources", label = "Click in the box below to add or remove resources:", choices = checkbox_resources(), selected = current_selection())
+    if (is.null(current_selection())) {
+      return(NULL)
+    } else {
+      updateSelectizeInput(session, "resources", label = "Click in the box below to add or remove resources:", choices = checkbox_resources(), selected = current_selection(), options = list("plugins" = list("remove_button"), "create" = TRUE, "persist" = FALSE))
+    }
   })
 
   #                     #

--- a/shinydashboard/lantern/server.R
+++ b/shinydashboard/lantern/server.R
@@ -244,6 +244,18 @@ function(input, output, session) { #nolint
     return(res)
   })
 
+  checkbox_resources_no_filter <- reactive({
+    res <- isolate(app_data$endpoint_resource_types())
+
+    res <- res %>%
+           distinct(type) %>%
+           arrange(type) %>%
+           split(.$type) %>%
+           purrr::map(~ .$type)
+
+    return(res)
+  })
+
   output$show_resource_checkboxes <- renderUI({
     if (show_resource_checkbox()) {
       fluidPage(
@@ -255,7 +267,7 @@ function(input, output, session) { #nolint
             Resources that are filtered out of the selected list will not re-appear in the list if you make other changes to the FHIR Version or Developer filtering criteria.
             You must either (1) select a resource from the resources drop down to add it to the list, or (2) click the 'Select All Resources' button to add all resources that are supported by the endpoints passing the selected criteria.", style = "font-size:19px; margin-left:5px;"),
           p("Note: This is the list of FHIR resource types reported by the capability statements from the endpoints. This reflects the most recent successful response only. Endpoints which are down, unreachable during the last query or have not returned a valid capability statement, are not included in this list.", style = "font-size:15px; margin-left:5px;"),
-          selectizeInput("resources", "Click in the box below to add or remove resources:", choices = checkbox_resources(), selected = checkbox_resources(), multiple = TRUE, options = list("plugins" = list("remove_button"), "create" = TRUE, "persist" = FALSE), width = "100%"),
+          selectizeInput("resources", "Click in the box below to add or remove resources:", choices = checkbox_resources_no_filter(), selected = checkbox_resources_no_filter(), multiple = TRUE, options = list("plugins" = list("remove_button"), "create" = TRUE, "persist" = FALSE), width = "100%"),
           actionButton("selectall", "Select All Resources", style = "margin-top: -15px; margin-bottom: 20px;"),
           actionButton("removeall", "Remove All Resources", style = "margin-top: -15px; margin-bottom: 20px;")
         )
@@ -289,7 +301,7 @@ function(input, output, session) { #nolint
   })
 
   observeEvent(input$fhir_version, {
-    if (is.null(current_selection())) {
+    if (!show_resource_checkbox() || is.null(current_selection() )) {
       return(NULL)
     } else {
       updateSelectizeInput(session, "resources", label = "Click in the box below to add or remove resources:", choices = checkbox_resources(), selected = current_selection(), options = list("plugins" = list("remove_button"), "create" = TRUE, "persist" = FALSE))
@@ -297,7 +309,7 @@ function(input, output, session) { #nolint
   })
 
   observeEvent(input$vendor, {
-    if (is.null(current_selection())) {
+    if (!show_resource_checkbox() || is.null(current_selection())) {
       return(NULL)
     } else {
       updateSelectizeInput(session, "resources", label = "Click in the box below to add or remove resources:", choices = checkbox_resources(), selected = current_selection(), options = list("plugins" = list("remove_button"), "create" = TRUE, "persist" = FALSE))

--- a/shinydashboard/lantern/server.R
+++ b/shinydashboard/lantern/server.R
@@ -301,7 +301,7 @@ function(input, output, session) { #nolint
   })
 
   observeEvent(input$fhir_version, {
-    if (!show_resource_checkbox() || is.null(current_selection() )) {
+    if (!show_resource_checkbox() || is.null(current_selection())) {
       return(NULL)
     } else {
       updateSelectizeInput(session, "resources", label = "Click in the box below to add or remove resources:", choices = checkbox_resources(), selected = current_selection(), options = list("plugins" = list("remove_button"), "create" = TRUE, "persist" = FALSE))


### PR DESCRIPTION
Changes in this PR:
Fixed the bug causing the capability tab not to load all resources when directly navigating to that tab. Also fixed bug where changing the fhir version or vendor filter on another tab affected the capability tab resource filter.

TO TEST:

- If you navigate directly to the capability tab all the resources should be selected
- If you navigate to the endpoint tab, change fhir version to 3.0.1, and then switch to the capability tab, all resources should be selected (they should not be filtered by fhir version)
- If you hit remove all, then switch fhir version or vendor filters, the resource list should remain empty
- If you navigate to a filter that has less available resource options, the resource list should automatically update to remove any resources that do not apply to the filter. Then if you pick a filter that has more available resource options, the resource list should not update to add the additional resource options

Pull requests into this repository require the following checks to be completed by the submitter and reviewers.

**Submitter:**
- [x] Administrative tasks are complete.
  - This pull request describes why these changes were made.
  - The JIRA ticket links to this PR.
  - The JIRA ticket for this PR is: [Lantern 340 JIRA Ticket](https://oncprojectracking.healthit.gov/support/browse/LANTERN-340)
- [x] Tests are complete.
  - Tests are included and test edge cases.
  - Tests have been run locally and pass.
- [x] Code review has been performed.
  - Code diff has been done and checked to ensure only expected code is being committed.
  - A linter for the language has been run.

**Primary Reviewer:**

- [x] Code works.
  - Code has been run locally and the basic functionality affected by the PR has been checked.
  - Edge cases have been checked to ensure behavior is as expected.
- [x] Code review has been performed.
  - Code is maintainable, reusable, efficient, and correct.
  - Code accomplishes the tasks purpose.
  - Code follows style guidance appropriate for the language, including passing linter checks.
  - Code is well commented (which does not mean verbosely commented).
- [x] Tests are complete.
  - Tests are included and test edge cases.
  - Tests have been run locally and pass.

**Secondary Reviewer:**

- [ ] Code works.
  - Code has been run locally and the basic functionality affected by the PR has been checked.
  - Edge cases have been checked to ensure behavior is as expected.
- [ ] Code review has been performed.
  - Code accomplishes the tasks purpose.
- [ ] Tests are complete.
  - Tests have been run locally and pass.

**Merger:**

Prior to merging, ensure that all checks have been completed. Delete the branch after the merge
is complete.

Create a new branch `<branch name>_gomodupdate`. Run `make update_mods` to update the `go.mod`
and `go.sum` files to point to master. Create a PR. Require one sanity check reviewer.
