### PR TITLE
Fix CHPL User Agent Bug

### DIFF
--- a/endpointmanager/cmd/chplquerier/main.go
+++ b/endpointmanager/cmd/chplquerier/main.go
@@ -40,6 +40,7 @@ func main() {
 	versionString := string(version)
 	versionNum := strings.Split(versionString, "=")
 	userAgent := "LANTERN/" + versionNum[1]
+	userAgent = strings.TrimSuffix(userAgent, "\n")
 	log.Infof("user agent is %s", userAgent)
 
 	err = chplquerier.GetCHPLCriteria(ctx, store, client, userAgent)


### PR DESCRIPTION
Pull requests into this repository require the following checks to be completed by the submitter and reviewers.
Changes in this PR:
The bug, `net/http: invalid header field value "LANTERN/1.4.0\n" for key User-Agent`, that was causing the GET request to https://chpl.healthit.gov/rest/data/certification-criteria to fail has been fixed. Code has been added to remove the `\n` at the end of the User Agent string.

**Submitter:**
- [x] Administrative tasks are complete.
  - This pull request describes why these changes were made.
  - The JIRA ticket links to this PR.
  - The JIRA ticket for this PR is: [Lantern 441 JIRA Ticket](https://oncprojectracking.healthit.gov/support/browse/LANTERN-441)
- [x] Tests are complete.
  - Tests are included and test edge cases.
  - Tests have been run locally and pass.
- [x] Code review has been performed.
  - Code diff has been done and checked to ensure only expected code is being committed.
  - A linter for the language has been run.

**Primary Reviewer:**

- [x] Code works.
  - Code has been run locally and the basic functionality affected by the PR has been checked.
  - Edge cases have been checked to ensure behavior is as expected.
- [x] Code review has been performed.
  - Code is maintainable, reusable, efficient, and correct.
  - Code accomplishes the tasks purpose.
  - Code follows style guidance appropriate for the language, including passing linter checks.
  - Code is well commented (which does not mean verbosely commented).
- [x] Tests are complete.
  - Tests are included and test edge cases.
  - Tests have been run locally and pass.

**Merger:**

Prior to merging, ensure that all checks have been completed. Delete the branch after the merge
is complete.
