### PR TITLE
Increased CHPL timeout time

### DIFF
--- a/e2e/integration_tests/data_flow_test.go
+++ b/e2e/integration_tests/data_flow_test.go
@@ -363,7 +363,7 @@ func Test_GetCHPLProducts(t *testing.T) {
 
 	ctx := context.Background()
 	client := &http.Client{
-		Timeout: time.Second * 35,
+		Timeout: time.Second * 60,
 	}
 	err = chplquerier.GetCHPLProducts(ctx, store, client, "")
 	helpers.FailOnError("", err)
@@ -401,7 +401,7 @@ func Test_GetCHPLProducts(t *testing.T) {
 		CertificationDate:     time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC),
 		CertificationEdition:  "2014",
 		CHPLID:                "CHP-029177",
-		CertificationCriteria: []int{100, 101, 103, 106, 107, 108, 109, 114, 115, 116, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 81, 82, 83, 84, 86, 87, 88, 91, 92, 93, 94, 95, 96, 97, 98, 99},
+		CertificationCriteria: []int{64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 81, 82, 83, 84, 86, 87, 88, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 103, 106, 107, 108, 109, 114, 115, 116, 61, 62, 63},
 	}
 
 	hitp, err := store.GetHealthITProductUsingNameAndVersion(ctx, "Intuitive Medical Document", "2.0")
@@ -411,7 +411,7 @@ func Test_GetCHPLProducts(t *testing.T) {
 	th.Assert(t, hitp.VendorID == testHITP.VendorID, "Developer is not what was expected")
 	th.Assert(t, hitp.CertificationDate.Equal(testHITP.CertificationDate), "Certification date is not what was expected")
 	th.Assert(t, hitp.CertificationStatus == testHITP.CertificationStatus, "Certification status is not what was expected")
-	th.Assert(t, reflect.DeepEqual(hitp.CertificationCriteria, testHITP.CertificationCriteria), "Certification criteria is not what was expected")
+	th.Assert(t, reflect.DeepEqual(hitp.CertificationCriteria, testHITP.CertificationCriteria), fmt.Sprintf("Certification criteria %v is not what was expected %v", hitp.CertificationCriteria, testHITP.CertificationCriteria))
 
 	// check that there are links in the product_criteria database
 	var link_count int

--- a/endpointmanager/cmd/chplquerier/main.go
+++ b/endpointmanager/cmd/chplquerier/main.go
@@ -29,7 +29,7 @@ func main() {
 
 	ctx := context.Background()
 	client := &http.Client{
-		Timeout: time.Second * 35,
+		Timeout: time.Second * 60,
 	}
 
 	// Read version file that is mounted to make user agent


### PR DESCRIPTION
Pull requests into this repository require the following checks to be completed by the submitter and reviewers.
Changes in this PR:
Fixed CHPL e2e test Test_GetCHPLProducts that was failing due to the certification criteria list for a product changing order. Also increased context timeout for CHPL querying which was causing the CHPL product querier to occasionally crash due to the timeout not being long enough

**Submitter:**
- [ ] Administrative tasks are complete.
  - This pull request describes why these changes were made.
  - The JIRA ticket links to this PR.
  - The JIRA ticket for this PR is: [Lantern 446 JIRA Ticket](https://oncprojectracking.healthit.gov/support/browse/LANTERN-446)
- [ ] Tests are complete.
  - Tests are included and test edge cases.
  - Tests have been run locally and pass.
- [ ] Code review has been performed.
  - Code diff has been done and checked to ensure only expected code is being committed.
  - A linter for the language has been run.

**Primary Reviewer:**

- [ ] Code works.
  - Code has been run locally and the basic functionality affected by the PR has been checked.
  - Edge cases have been checked to ensure behavior is as expected.
- [ ] Code review has been performed.
  - Code is maintainable, reusable, efficient, and correct.
  - Code accomplishes the tasks purpose.
  - Code follows style guidance appropriate for the language, including passing linter checks.
  - Code is well commented (which does not mean verbosely commented).
- [ ] Tests are complete.
  - Tests are included and test edge cases.
  - Tests have been run locally and pass.

**Merger:**

Prior to merging, ensure that all checks have been completed. Delete the branch after the merge
is complete.
