### PR TITLE
Invalid Cap Stat Display

### DIFF
--- a/db/migration/migrations/000016_add_kind.down.sql
+++ b/db/migration/migrations/000016_add_kind.down.sql
@@ -1,0 +1,29 @@
+BEGIN;
+
+DROP VIEW IF EXISTS endpoint_export;
+
+CREATE or REPLACE VIEW endpoint_export AS
+SELECT endpts.url, endpts.list_source, endpts.organization_names AS endpoint_names,
+    vendors.name as vendor_name,
+    endpts_info.tls_version, endpts_info.mime_types, endpts_metadata.http_response,
+    endpts_metadata.response_time_seconds, endpts_metadata.smart_http_response, endpts_metadata.errors,
+    EXISTS (SELECT 1 FROM fhir_endpoints_info WHERE capability_statement != 'null' AND endpts.url = fhir_endpoints_info.url) as CAP_STAT_EXISTS,
+    endpts_info.capability_fhir_version AS FHIR_VERSION,
+    endpts_info.capability_statement->>'publisher' AS PUBLISHER,
+    endpts_info.capability_statement->'software'->'name' AS SOFTWARE_NAME,
+    endpts_info.capability_statement->'software'->'version' AS SOFTWARE_VERSION,
+    endpts_info.capability_statement->'software'->'releaseDate' AS SOFTWARE_RELEASEDATE,
+    endpts_info.capability_statement->'format' AS FORMAT,
+    endpts_info.updated_at AS INFO_UPDATED, endpts_info.created_at AS INFO_CREATED,
+    endpts_info.requested_fhir_version,
+    orgs.name AS ORGANIZATION_NAME, orgs.secondary_name AS ORGANIZATION_SECONDARY_NAME,
+    orgs.taxonomy, orgs.Location->>'state' AS STATE, orgs.Location->>'zipcode' AS ZIPCODE,
+    links.confidence AS MATCH_SCORE, endpts_metadata.availability
+FROM endpoint_organization AS links
+RIGHT JOIN fhir_endpoints AS endpts ON links.url = endpts.url
+LEFT JOIN fhir_endpoints_info AS endpts_info ON endpts.url = endpts_info.url
+LEFT JOIN fhir_endpoints_metadata AS endpts_metadata ON endpts_info.metadata_id = endpts_metadata.id
+LEFT JOIN vendors ON endpts_info.vendor_id = vendors.id
+LEFT JOIN npi_organizations AS orgs ON links.organization_npi_id = orgs.npi_id;
+
+COMMIT;

--- a/db/migration/migrations/000016_add_kind.up.sql
+++ b/db/migration/migrations/000016_add_kind.up.sql
@@ -1,0 +1,30 @@
+BEGIN;
+
+DROP VIEW IF EXISTS endpoint_export;
+
+CREATE or REPLACE VIEW endpoint_export AS
+SELECT endpts.url, endpts.list_source, endpts.organization_names AS endpoint_names,
+    vendors.name as vendor_name,
+    endpts_info.tls_version, endpts_info.mime_types, endpts_metadata.http_response,
+    endpts_metadata.response_time_seconds, endpts_metadata.smart_http_response, endpts_metadata.errors,
+    EXISTS (SELECT 1 FROM fhir_endpoints_info WHERE capability_statement != 'null' AND endpts.url = fhir_endpoints_info.url) as CAP_STAT_EXISTS,
+    endpts_info.capability_fhir_version AS FHIR_VERSION,
+    endpts_info.capability_statement->>'publisher' AS PUBLISHER,
+    endpts_info.capability_statement->'software'->'name' AS SOFTWARE_NAME,
+    endpts_info.capability_statement->'software'->'version' AS SOFTWARE_VERSION,
+    endpts_info.capability_statement->'software'->'releaseDate' AS SOFTWARE_RELEASEDATE,
+    endpts_info.capability_statement->'format' AS FORMAT,
+    endpts_info.capability_statement->>'kind' AS KIND,
+    endpts_info.updated_at AS INFO_UPDATED, endpts_info.created_at AS INFO_CREATED,
+    endpts_info.requested_fhir_version,
+    orgs.name AS ORGANIZATION_NAME, orgs.secondary_name AS ORGANIZATION_SECONDARY_NAME,
+    orgs.taxonomy, orgs.Location->>'state' AS STATE, orgs.Location->>'zipcode' AS ZIPCODE,
+    links.confidence AS MATCH_SCORE, endpts_metadata.availability
+FROM endpoint_organization AS links
+RIGHT JOIN fhir_endpoints AS endpts ON links.url = endpts.url
+LEFT JOIN fhir_endpoints_info AS endpts_info ON endpts.url = endpts_info.url
+LEFT JOIN fhir_endpoints_metadata AS endpts_metadata ON endpts_info.metadata_id = endpts_metadata.id
+LEFT JOIN vendors ON endpts_info.vendor_id = vendors.id
+LEFT JOIN npi_organizations AS orgs ON links.organization_npi_id = orgs.npi_id;
+
+COMMIT;

--- a/db/sql/dbsetup.sql
+++ b/db/sql/dbsetup.sql
@@ -327,6 +327,7 @@ SELECT endpts.url, endpts.list_source, endpts.organization_names AS endpoint_nam
     endpts_info.capability_statement->'software'->'version' AS SOFTWARE_VERSION,
     endpts_info.capability_statement->'software'->'releaseDate' AS SOFTWARE_RELEASEDATE,
     endpts_info.capability_statement->'format' AS FORMAT,
+    endpts_info.capability_statement->>'kind' AS KIND,
     endpts_info.updated_at AS INFO_UPDATED, endpts_info.created_at AS INFO_CREATED,
     endpts_info.requested_fhir_version,
     orgs.name AS ORGANIZATION_NAME, orgs.secondary_name AS ORGANIZATION_SECONDARY_NAME,

--- a/shinydashboard/lantern/global.R
+++ b/shinydashboard/lantern/global.R
@@ -48,7 +48,9 @@ ui_special_values <- list(
 # The list of fhir versions and vendors are unlikely to change during a user's session
 # we'll update them on timer, but not refresh the UI
 app <<- list(
-  fhir_version_list      = reactiveVal(get_fhir_version_list(endpoint_export_tbl)),
+  fhir_version_list_no_capstat      = reactiveVal(get_fhir_version_list(endpoint_export_tbl, TRUE)),
+  fhir_version_list      = reactiveVal(get_fhir_version_list(endpoint_export_tbl, FALSE)),
+  distinct_fhir_version_list_no_capstat      = reactiveVal(get_distinct_fhir_version_list_no_capstat(endpoint_export_tbl)),
   distinct_fhir_version_list      = reactiveVal(get_distinct_fhir_version_list(endpoint_export_tbl)),
   vendor_list            = get_vendor_list(endpoint_export_tbl),
   http_response_code_tbl =

--- a/shinydashboard/lantern/modules/endpointsmodule.R
+++ b/shinydashboard/lantern/modules/endpointsmodule.R
@@ -15,7 +15,7 @@ endpointsmodule_UI <- function(id) {
       ),
     ),
     reactable::reactableOutput(ns("endpoints_table")),
-    p("* An asterisk after a true value in the capbility statement returned field indicates that the returned capability statement for the endpoint is not of kind 'instance' as expected."),
+    p("* An asterisk after a 'true' value in the 'Capability Statement Returned' field indicates that the returned Capability Statement for the endpoint is not of kind 'instance', which is the kind Lantern expects."),
     htmlOutput(ns("note_text"))
   )
 }

--- a/shinydashboard/lantern/modules/endpointsmodule.R
+++ b/shinydashboard/lantern/modules/endpointsmodule.R
@@ -15,6 +15,7 @@ endpointsmodule_UI <- function(id) {
       ),
     ),
     reactable::reactableOutput(ns("endpoints_table")),
+    p("* An asterisk after a true value in the capbility statement returned field indicates that the returned capability statement for the endpoint is not of kind 'instance' as expected."),
     htmlOutput(ns("note_text"))
   )
 }

--- a/shinydashboard/lantern/server.R
+++ b/shinydashboard/lantern/server.R
@@ -165,6 +165,10 @@ function(input, output, session) { #nolint
     input$side_menu %in% c("endpoints_tab", "resource_tab", "implementation_tab", "fields_tab", "security_tab", "smartresponse_tab", "location_tab", "values_tab", "capabilitystatementsize_tab", "validations_tab", "profile_tab")
   )
 
+  fhir_version_no_capstat <- reactive(
+    input$side_menu %in% c("endpoints_tab", "smartresponse_tab", "location_tab", "validations_tab")
+  )
+
   show_availability_filter <- reactive(
     input$side_menu %in% c("endpoints_tab")
   )
@@ -196,7 +200,11 @@ function(input, output, session) { #nolint
 
   output$show_filters <- renderUI({
     if (show_filter()) {
-      fhirDropdown <- pickerInput(inputId = "fhir_version", label = "FHIR Version:", multiple = TRUE, choices = isolate(app$fhir_version_list()), selected = isolate(app$distinct_fhir_version_list()), options = list(`actions-box` = TRUE, `multiple-separator` = " | ", size = 5))
+      if (fhir_version_no_capstat()) {
+        fhirDropdown <- pickerInput(inputId = "fhir_version", label = "FHIR Version:", multiple = TRUE, choices = isolate(app$fhir_version_list_no_capstat()), selected = isolate(app$distinct_fhir_version_list_no_capstat()), options = list(`actions-box` = TRUE, `multiple-separator` = " | ", size = 5))
+      } else {
+        fhirDropdown <- pickerInput(inputId = "fhir_version", label = "FHIR Version:", multiple = TRUE, choices = isolate(app$fhir_version_list()), selected = isolate(app$distinct_fhir_version_list()), options = list(`actions-box` = TRUE, `multiple-separator` = " | ", size = 5))
+      }
       developerDropdown <- selectInput(inputId = "vendor", label = "Developer:", choices = app$vendor_list, selected = ui_special_values$ALL_DEVELOPERS, size = 1, selectize = FALSE)
       availabilityDropdown <- selectInput(inputId = "availability", label = "Availability Percentage:", choices = list("0-100", "0", "50-100", "75-100", "95-100", "99-100", "100"), selected = "0-100", size = 1, selectize = FALSE)
       validationsDropdown <- selectInput(inputId = "validation_group", label = "Validation Group", choices = c("All Groups", validation_group_names), selected = "All Groups", size = 1, selectize = FALSE)


### PR DESCRIPTION
Pull requests into this repository require the following checks to be completed by the submitter and reviewers.
Changes in this PR:
Made changes to how invalid capability statements are displayed on the shiny dashboard:
1. Endpoint page: Changed the "Capability Statement Returned" column so that if kind == instance its true, if kind != instance its true*, else false
2. Added note to bottom of page that defines true*
3. Removed "No Cap Stat" option on FHIR version dropdown where the page is looking at capability statement data- only include on the endpoint, validation, smart response, and location tabs

**Submitter:**
- [x] Administrative tasks are complete.
  - This pull request describes why these changes were made.
  - The JIRA ticket links to this PR.
  - The JIRA ticket for this PR is: [Lantern 444 JIRA Ticket](https://oncprojectracking.healthit.gov/support/browse/LANTERN-444)
- [x] Tests are complete.
  - Tests are included and test edge cases.
  - Tests have been run locally and pass.
- [x] Code review has been performed.
  - Code diff has been done and checked to ensure only expected code is being committed.
  - A linter for the language has been run.

**Primary Reviewer:**

- [x] Code works.
  - Code has been run locally and the basic functionality affected by the PR has been checked.
  - Edge cases have been checked to ensure behavior is as expected.
- [x] Code review has been performed.
  - Code is maintainable, reusable, efficient, and correct.
  - Code accomplishes the tasks purpose.
  - Code follows style guidance appropriate for the language, including passing linter checks.
  - Code is well commented (which does not mean verbosely commented).
- [x] Tests are complete.
  - Tests are included and test edge cases.
  - Tests have been run locally and pass.

**Merger:**

Prior to merging, ensure that all checks have been completed. Delete the branch after the merge
is complete.
