### PR TITLE
LANTERN-721: Increased the time delay between CHPL API Requests to 1.2 seconds

### DIFF
--- a/endpointmanager/pkg/chplquerier/chplquerier.go
+++ b/endpointmanager/pkg/chplquerier/chplquerier.go
@@ -47,6 +47,7 @@ func makeCHPLURL(path string, queryArgs map[string]string, pageSize int, pageNum
 func getJSON(ctx context.Context, client *http.Client, chplURL *url.URL, userAgent string) ([]byte, error) {
 	// request ceritified products list
 	// Adds a short delay between request
+	// LANTERN-721: Increased the delay to 1.2 seconds since the CHPL API rate limit is one request per second
 	time.Sleep(time.Duration(1200 * time.Millisecond))
 	req, err := http.NewRequest("GET", chplURL.String(), nil)
 	if err != nil {

--- a/endpointmanager/pkg/chplquerier/chplquerier.go
+++ b/endpointmanager/pkg/chplquerier/chplquerier.go
@@ -47,7 +47,7 @@ func makeCHPLURL(path string, queryArgs map[string]string, pageSize int, pageNum
 func getJSON(ctx context.Context, client *http.Client, chplURL *url.URL, userAgent string) ([]byte, error) {
 	// request ceritified products list
 	// Adds a short delay between request
-	time.Sleep(time.Duration(500 * time.Millisecond))
+	time.Sleep(time.Duration(1200 * time.Millisecond))
 	req, err := http.NewRequest("GET", chplURL.String(), nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating http request failed")


### PR DESCRIPTION
Pull requests into this repository require the following checks to be completed by the submitter and reviewers.

**Submitter:**
- [x] Administrative tasks are complete.
  - This pull request describes why these changes were made.
  - The JIRA ticket links to this PR.
  - The JIRA ticket for this PR is: 
- [x] Tests are complete.
  - Tests are included and test edge cases.
  - Tests have been run locally and pass.
- [x] Code review has been performed.
  - Code diff has been done and checked to ensure only expected code is being committed.
  - A linter for the language has been run.

**Primary Reviewer:**

- [x] Code works.
  - Code has been run locally and the basic functionality affected by the PR has been checked.
  - Edge cases have been checked to ensure behavior is as expected.
- [x] Code review has been performed.
  - Code is maintainable, reusable, efficient, and correct.
  - Code accomplishes the tasks purpose.
  - Code follows style guidance appropriate for the language, including passing linter checks.
  - Code is well commented (which does not mean verbosely commented).
- [x] Tests are complete.
  - Tests are included and test edge cases.
  - Tests have been run locally and pass.

**Merger:**

Prior to merging, ensure that all checks have been completed. Delete the branch after the merge
is complete.
