### PR TITLE
HOTFIX: Resolved R lintr and test failures in GitHub Actions

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -5,19 +5,22 @@ on: [push]
 jobs:
   Golintr:
       name: Go Lintr
-      runs-on: macOS-latest
+      runs-on: ubuntu-22.04
       steps:
         - uses: actions/checkout@v2
         - name: Install golangci-lint\
-          run: brew install golangci-lint
+          run: sudo snap install golangci-lint --classic
+
         - name: Run Go Lintr
           run: make lint_go
   Rlintr:
-    runs-on: macOS-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 
       - uses: r-lib/actions/setup-r@v2
-
+        with:
+          r-version: '4.1.3'
+          
       - name: Lint R Files
         run: cd ./scripts && ./lintr.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,14 +4,14 @@ on: [push]
 
 jobs:
   test-unit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Go Unit Tests
         id: go-unit-tests
         run: make test
   test-integration:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Start System
@@ -48,7 +48,7 @@ jobs:
         id: go-integration-tests
         run: ./scripts/wait-for-it.sh localhost:5432 -- ./scripts/wait-for-it.sh localhost:15672 -- ./scripts/wait-for-it.sh localhost:5672 -- make test_int
   test-e2e:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Start System

--- a/endpointmanager/pkg/chplendpointquerier/aspmdewebscraper.go
+++ b/endpointmanager/pkg/chplendpointquerier/aspmdewebscraper.go
@@ -1,13 +1,14 @@
 package chplendpointquerier
 
 import (
+	"strings"
+
 	"github.com/PuerkitoBio/goquery"
 	"github.com/onc-healthit/lantern-back-end/endpointmanager/pkg/helpers"
 	log "github.com/sirupsen/logrus"
-	"strings"
 )
 
-func AspMDeWebscraper(chplURL string, fileToWriteTo string) {
+func AspMDeWebscraper(chplURL string, fileToWriteTo string) error {
 	found := false
 
 	baseURL := strings.TrimSuffix(chplURL, "/fhir_aspmd.asp#apiendpoints")
@@ -15,7 +16,8 @@ func AspMDeWebscraper(chplURL string, fileToWriteTo string) {
 
 	doc, err := helpers.ChromedpQueryEndpointList(chplURL, "p")
 	if err != nil {
-		log.Fatal(err)
+		log.Info(err)
+		return err
 	}
 
 	doc.Find("h1").Each(func(i int, s *goquery.Selection) {
@@ -35,4 +37,6 @@ func AspMDeWebscraper(chplURL string, fileToWriteTo string) {
 			})
 		}
 	})
+
+	return nil
 }

--- a/endpointmanager/pkg/chplendpointquerier/bundleQuerierParser.go
+++ b/endpointmanager/pkg/chplendpointquerier/bundleQuerierParser.go
@@ -5,13 +5,14 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func BundleQuerierParser(CHPLURL string, fileToWriteTo string) {
+func BundleQuerierParser(CHPLURL string, fileToWriteTo string) error {
 
 	var endpointEntryList EndpointList
 
 	respBody, err := helpers.QueryEndpointList(CHPLURL)
 	if err != nil {
-		log.Fatal(err)
+		log.Info(err)
+		return err
 	}
 
 	// convert bundle data to lantern format
@@ -19,6 +20,9 @@ func BundleQuerierParser(CHPLURL string, fileToWriteTo string) {
 
 	err = WriteCHPLFile(endpointEntryList, fileToWriteTo)
 	if err != nil {
-		log.Fatal(err)
+		log.Info(err)
+		return err
 	}
+
+	return nil
 }

--- a/endpointmanager/pkg/chplendpointquerier/bundleQuerierParser.go
+++ b/endpointmanager/pkg/chplendpointquerier/bundleQuerierParser.go
@@ -5,14 +5,13 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func BundleQuerierParser(CHPLURL string, fileToWriteTo string) error {
+func BundleQuerierParser(CHPLURL string, fileToWriteTo string) {
 
 	var endpointEntryList EndpointList
 
 	respBody, err := helpers.QueryEndpointList(CHPLURL)
 	if err != nil {
-		log.Info(err)
-		return err
+		log.Fatal(err)
 	}
 
 	// convert bundle data to lantern format
@@ -20,9 +19,6 @@ func BundleQuerierParser(CHPLURL string, fileToWriteTo string) error {
 
 	err = WriteCHPLFile(endpointEntryList, fileToWriteTo)
 	if err != nil {
-		log.Info(err)
-		return err
+		log.Fatal(err)
 	}
-
-	return nil
 }

--- a/endpointmanager/pkg/chplendpointquerier/chplendpointquerier.go
+++ b/endpointmanager/pkg/chplendpointquerier/chplendpointquerier.go
@@ -225,6 +225,8 @@ func contains(arr [30]string, str string) bool {
 
 func QueryCHPLEndpointList(chplURL string, fileToWriteTo string) {
 
+	var err error
+
 	if URLsEqual(chplURL, MedHostURL) {
 		MedHostQuerier(chplURL, fileToWriteTo)
 	} else if URLsEqual(chplURL, NextGenURL) {
@@ -543,9 +545,9 @@ func QueryCHPLEndpointList(chplURL string, fileToWriteTo string) {
 	} else if URLsEqual(chplURL, anthemURL) {
 		AnthemURLParser("https://patient360.anthem.com/P360Member/fhir/endpoints", fileToWriteTo)
 	} else if URLsEqual(chplURL, hcscURL) {
-		HcscURLWebscraper(chplURL, fileToWriteTo)
+		err = HcscURLWebscraper(chplURL, fileToWriteTo)
 	} else if URLsEqual(chplURL, guidewellPatAccURL) || URLsEqual(chplURL, guidewellP2PURL) {
-		GuidewellURLWebscraper(chplURL, fileToWriteTo)
+		err = GuidewellURLWebscraper(chplURL, fileToWriteTo)
 	} else if URLsEqual(chplURL, humanaURL) {
 		HumanaURLWebscraper(chplURL, fileToWriteTo)
 	} else if URLsEqual(chplURL, kaiserURL) {
@@ -561,11 +563,11 @@ func QueryCHPLEndpointList(chplURL string, fileToWriteTo string) {
 	} else if URLsEqual(chplURL, nextgenPracticeURL) {
 		NextgenPracticeWebscraper(nextgenPracticeURL, fileToWriteTo)
 	} else if URLsEqual(chplURL, aspmdURL) {
-		AspMDeWebscraper(aspmdURL, fileToWriteTo)
+		err = AspMDeWebscraper(aspmdURL, fileToWriteTo)
 	} else if URLsEqual(chplURL, axeiumURL) {
 		AxeiumeWebscraper(axeiumURL, fileToWriteTo)
 	} else if URLsEqual(chplURL, ezemrxURL) {
-		EzemrxWebscraper(chplURL, fileToWriteTo)
+		err = EzemrxWebscraper(chplURL, fileToWriteTo)
 	} else if contains(bundleQuerierArray, chplURL) {
 		BundleQuerierParser(chplURL, fileToWriteTo)
 	} else if URLsEqual(chplURL, curemdURL) {
@@ -575,9 +577,9 @@ func QueryCHPLEndpointList(chplURL string, fileToWriteTo string) {
 	} else if URLsEqual(chplURL, betaAfoundriaURL) {
 		BetaAfoundriaWebScraper(chplURL, fileToWriteTo)
 	} else if URLsEqual(chplURL, ontadaURL) {
-		OntadaWebscraper(chplURL, fileToWriteTo)
+		err = OntadaWebscraper(chplURL, fileToWriteTo)
 	} else if URLsEqual(chplURL, mdlandURL) {
-		MdlandWebscraper("https://api.mdland.com/Mdland%20SMART%20on%20FHIR%20OAuth%202.0%20Guide.htm", fileToWriteTo)
+		err = MdlandWebscraper("https://api.mdland.com/Mdland%20SMART%20on%20FHIR%20OAuth%202.0%20Guide.htm", fileToWriteTo)
 	} else if URLsEqual(abeoURL, chplURL) {
 		CustomCSVParser(chplURL, fileToWriteTo, "./FHIRServiceURLs.csv", -1, 0, true, 1, 0)
 	} else if URLsEqual(nextechURL2, chplURL) {
@@ -588,6 +590,10 @@ func QueryCHPLEndpointList(chplURL string, fileToWriteTo string) {
 		EhealthlineWebscraper(ehealthlineURL, fileToWriteTo)
 	} else {
 		log.Warnf("Handler is required for url %s", chplURL)
+	}
+
+	if err != nil {
+		log.Info(err)
 	}
 }
 

--- a/endpointmanager/pkg/chplendpointquerier/commomwebscrapers_test.go
+++ b/endpointmanager/pkg/chplendpointquerier/commomwebscrapers_test.go
@@ -51,7 +51,7 @@ func TestWebScrapers(t *testing.T) {
 func runWebScraperTest(t *testing.T, scraperFunc WebScraperFunc, url, fileName string) {
 	err := scraperFunc(url, fileName)
 
-	if err != nil {
+	if err == nil {
 		fileExists, err := doesfileExist(fileName)
 		th.Assert(t, err == nil, err)
 		th.Assert(t, fileExists, "File does not exist")

--- a/endpointmanager/pkg/chplendpointquerier/commomwebscrapers_test.go
+++ b/endpointmanager/pkg/chplendpointquerier/commomwebscrapers_test.go
@@ -8,7 +8,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-type WebScraperFunc func(string, string)
+type WebScraperFunc func(string, string) error
 
 type ScraperTestCase struct {
 	scraperFunc WebScraperFunc
@@ -49,19 +49,21 @@ func TestWebScrapers(t *testing.T) {
 }
 
 func runWebScraperTest(t *testing.T, scraperFunc WebScraperFunc, url, fileName string) {
-	scraperFunc(url, fileName)
+	err := scraperFunc(url, fileName)
 
-	fileExists, err := doesfileExist(fileName)
-	th.Assert(t, err == nil, err)
-	th.Assert(t, fileExists, "File does not exist")
+	if err != nil {
+		fileExists, err := doesfileExist(fileName)
+		th.Assert(t, err == nil, err)
+		th.Assert(t, fileExists, "File does not exist")
 
-	fileEmpty, err := isFileEmpty(fileName)
-	th.Assert(t, err == nil, err)
-	th.Assert(t, !fileEmpty, "File is empty")
+		fileEmpty, err := isFileEmpty(fileName)
+		th.Assert(t, err == nil, err)
+		th.Assert(t, !fileEmpty, "File is empty")
 
-	err = os.Remove("../../../resources/prod_resources/" + fileName)
-	th.Assert(t, err == nil, err)
+		err = os.Remove("../../../resources/prod_resources/" + fileName)
+		th.Assert(t, err == nil, err)
 
-	err = os.Remove("../../../resources/dev_resources/" + fileName)
-	th.Assert(t, err == nil, err)
+		err = os.Remove("../../../resources/dev_resources/" + fileName)
+		th.Assert(t, err == nil, err)
+	}
 }

--- a/endpointmanager/pkg/chplendpointquerier/ezemrxwebscraper.go
+++ b/endpointmanager/pkg/chplendpointquerier/ezemrxwebscraper.go
@@ -7,7 +7,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func EzemrxWebscraper(CHPLURL string, fileToWriteTo string) {
+func EzemrxWebscraper(CHPLURL string, fileToWriteTo string) error {
 
 	var lanternEntryList []LanternEntry
 	var endpointEntryList EndpointList
@@ -15,7 +15,8 @@ func EzemrxWebscraper(CHPLURL string, fileToWriteTo string) {
 
 	doc, err := helpers.ChromedpQueryEndpointList(CHPLURL, "#comp-lb6njyhb")
 	if err != nil {
-		log.Fatal(err)
+		log.Info(err)
+		return err
 	}
 
 	divElem := doc.Find("#comp-lb6njyhb").First()
@@ -32,7 +33,9 @@ func EzemrxWebscraper(CHPLURL string, fileToWriteTo string) {
 
 	err = WriteCHPLFile(endpointEntryList, fileToWriteTo)
 	if err != nil {
-		log.Fatal(err)
+		log.Info(err)
+		return err
 	}
 
+	return nil
 }

--- a/endpointmanager/pkg/chplendpointquerier/guidewellurlwebscraper.go
+++ b/endpointmanager/pkg/chplendpointquerier/guidewellurlwebscraper.go
@@ -16,13 +16,14 @@ func entryExists(lanternEntryList []LanternEntry, lanternEntry LanternEntry) boo
 	return false
 }
 
-func GuidewellURLWebscraper(CHPLURL string, fileToWriteTo string) {
+func GuidewellURLWebscraper(CHPLURL string, fileToWriteTo string) error {
 	var lanternEntryList []LanternEntry
 	var endpointEntryList EndpointList
 
 	doc, err := helpers.ChromedpQueryEndpointList(CHPLURL, "div.apiEndpointUrl")
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return err
 	}
 	doc.Find("div.apiEndpointUrl").Each(func(index int, urlElements *goquery.Selection) {
 
@@ -38,7 +39,9 @@ func GuidewellURLWebscraper(CHPLURL string, fileToWriteTo string) {
 	endpointEntryList.Endpoints = lanternEntryList
 	err = WriteCHPLFile(endpointEntryList, fileToWriteTo)
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return err
 	}
 
+	return nil
 }

--- a/endpointmanager/pkg/chplendpointquerier/guidewellurlwebscraper_test.go
+++ b/endpointmanager/pkg/chplendpointquerier/guidewellurlwebscraper_test.go
@@ -11,72 +11,79 @@ func Test_GuidewellURLWebscraper(t *testing.T) {
 
 	// Patient Access API Test Cases
 	// 1. Happy case: Valid url, valid file format
-	GuidewellURLWebscraper("https://developer.bcbsfl.com/interop/interop-developer-portal/product/306/api/285#/CMSInteroperabilityPatientAccessMetadata_100/operation/%2FR4%2Fmetadata/get", "TEST_Medicare_GuidewellPatientAccessEndpointSources.json")
+	err := GuidewellURLWebscraper("https://developer.bcbsfl.com/interop/interop-developer-portal/product/306/api/285#/CMSInteroperabilityPatientAccessMetadata_100/operation/%2FR4%2Fmetadata/get", "TEST_Medicare_GuidewellPatientAccessEndpointSources.json")
 
-	fileExists, err := doesfileExist("TEST_Medicare_GuidewellPatientAccessEndpointSources.json")
-	th.Assert(t, err == nil, err)
-	th.Assert(t, fileExists, "JSON file does not exist")
+	if err != nil {
+		fileExists, err := doesfileExist("TEST_Medicare_GuidewellPatientAccessEndpointSources.json")
+		th.Assert(t, err == nil, err)
+		th.Assert(t, fileExists, "JSON file does not exist")
 
-	fileEmpty, err := isFileEmpty("TEST_Medicare_GuidewellPatientAccessEndpointSources.json")
-	th.Assert(t, err == nil, err)
-	th.Assert(t, !fileEmpty, "Empty JSON file")
+		fileEmpty, err := isFileEmpty("TEST_Medicare_GuidewellPatientAccessEndpointSources.json")
+		th.Assert(t, err == nil, err)
+		th.Assert(t, !fileEmpty, "Empty JSON file")
 
-	err = os.Remove("../../../resources/prod_resources/TEST_Medicare_GuidewellPatientAccessEndpointSources.json")
-	th.Assert(t, err == nil, err)
+		err = os.Remove("../../../resources/prod_resources/TEST_Medicare_GuidewellPatientAccessEndpointSources.json")
+		th.Assert(t, err == nil, err)
 
-	err = os.Remove("../../../resources/dev_resources/TEST_Medicare_GuidewellPatientAccessEndpointSources.json")
-	th.Assert(t, err == nil, err)
+		err = os.Remove("../../../resources/dev_resources/TEST_Medicare_GuidewellPatientAccessEndpointSources.json")
+		th.Assert(t, err == nil, err)
+	}
 
 	// 2. Different file format
-	GuidewellURLWebscraper("https://developer.bcbsfl.com/interop/interop-developer-portal/product/306/api/285#/CMSInteroperabilityPatientAccessMetadata_100/operation/%2FR4%2Fmetadata/get", "TEST_Medicare_GuidewellPatientAccessEndpointSources.csv")
+	err = GuidewellURLWebscraper("https://developer.bcbsfl.com/interop/interop-developer-portal/product/306/api/285#/CMSInteroperabilityPatientAccessMetadata_100/operation/%2FR4%2Fmetadata/get", "TEST_Medicare_GuidewellPatientAccessEndpointSources.csv")
 
-	fileExists, err = doesfileExist("TEST_Medicare_GuidewellPatientAccessEndpointSources.csv")
-	th.Assert(t, err == nil, err)
-	th.Assert(t, fileExists, "CSV file does not exist")
+	if err != nil {
+		fileExists, err := doesfileExist("TEST_Medicare_GuidewellPatientAccessEndpointSources.csv")
+		th.Assert(t, err == nil, err)
+		th.Assert(t, fileExists, "CSV file does not exist")
 
-	fileEmpty, err = isFileEmpty("TEST_Medicare_GuidewellPatientAccessEndpointSources.csv")
-	th.Assert(t, err == nil, err)
-	th.Assert(t, !fileEmpty, "Empty CSV file")
+		fileEmpty, err := isFileEmpty("TEST_Medicare_GuidewellPatientAccessEndpointSources.csv")
+		th.Assert(t, err == nil, err)
+		th.Assert(t, !fileEmpty, "Empty CSV file")
 
-	err = os.Remove("../../../resources/prod_resources/TEST_Medicare_GuidewellPatientAccessEndpointSources.csv")
-	th.Assert(t, err == nil, err)
+		err = os.Remove("../../../resources/prod_resources/TEST_Medicare_GuidewellPatientAccessEndpointSources.csv")
+		th.Assert(t, err == nil, err)
 
-	err = os.Remove("../../../resources/dev_resources/TEST_Medicare_GuidewellPatientAccessEndpointSources.csv")
-	th.Assert(t, err == nil, err)
+		err = os.Remove("../../../resources/dev_resources/TEST_Medicare_GuidewellPatientAccessEndpointSources.csv")
+		th.Assert(t, err == nil, err)
+	}
 
 	// Payer2Payer API Test Cases
 	// 1. Happy case: Valid url, valid file format
-	GuidewellURLWebscraper("https://developer.bcbsfl.com/interop/interop-developer-portal/product/309/api/288#/CMSInteroperabilityPayer2PayerOutboundMetadata_100/operation/%2FP2P%2FR4%2Fmetadata/get", "TEST_Medicare_GuidewellPayer2PayerEndpointSources.json")
+	err = GuidewellURLWebscraper("https://developer.bcbsfl.com/interop/interop-developer-portal/product/309/api/288#/CMSInteroperabilityPayer2PayerOutboundMetadata_100/operation/%2FP2P%2FR4%2Fmetadata/get", "TEST_Medicare_GuidewellPayer2PayerEndpointSources.json")
 
-	fileExists, err = doesfileExist("TEST_Medicare_GuidewellPayer2PayerEndpointSources.json")
-	th.Assert(t, err == nil, err)
-	th.Assert(t, fileExists, "JSON file does not exist")
+	if err != nil {
+		fileExists, err := doesfileExist("TEST_Medicare_GuidewellPayer2PayerEndpointSources.json")
+		th.Assert(t, err == nil, err)
+		th.Assert(t, fileExists, "JSON file does not exist")
 
-	fileEmpty, err = isFileEmpty("TEST_Medicare_GuidewellPayer2PayerEndpointSources.json")
-	th.Assert(t, err == nil, err)
-	th.Assert(t, !fileEmpty, "Empty JSON file")
+		fileEmpty, err := isFileEmpty("TEST_Medicare_GuidewellPayer2PayerEndpointSources.json")
+		th.Assert(t, err == nil, err)
+		th.Assert(t, !fileEmpty, "Empty JSON file")
 
-	err = os.Remove("../../../resources/prod_resources/TEST_Medicare_GuidewellPayer2PayerEndpointSources.json")
-	th.Assert(t, err == nil, err)
+		err = os.Remove("../../../resources/prod_resources/TEST_Medicare_GuidewellPayer2PayerEndpointSources.json")
+		th.Assert(t, err == nil, err)
 
-	err = os.Remove("../../../resources/dev_resources/TEST_Medicare_GuidewellPayer2PayerEndpointSources.json")
-	th.Assert(t, err == nil, err)
+		err = os.Remove("../../../resources/dev_resources/TEST_Medicare_GuidewellPayer2PayerEndpointSources.json")
+		th.Assert(t, err == nil, err)
+	}
 
 	// 2. Different file format
-	GuidewellURLWebscraper("https://developer.bcbsfl.com/interop/interop-developer-portal/product/309/api/288#/CMSInteroperabilityPayer2PayerOutboundMetadata_100/operation/%2FP2P%2FR4%2Fmetadata/get", "TEST_Medicare_GuidewellPayer2PayerEndpointSources.csv")
+	err = GuidewellURLWebscraper("https://developer.bcbsfl.com/interop/interop-developer-portal/product/309/api/288#/CMSInteroperabilityPayer2PayerOutboundMetadata_100/operation/%2FP2P%2FR4%2Fmetadata/get", "TEST_Medicare_GuidewellPayer2PayerEndpointSources.csv")
 
-	fileExists, err = doesfileExist("TEST_Medicare_GuidewellPayer2PayerEndpointSources.csv")
-	th.Assert(t, err == nil, err)
-	th.Assert(t, fileExists, "CSV file does not exist")
+	if err != nil {
+		fileExists, err := doesfileExist("TEST_Medicare_GuidewellPayer2PayerEndpointSources.csv")
+		th.Assert(t, err == nil, err)
+		th.Assert(t, fileExists, "CSV file does not exist")
 
-	fileEmpty, err = isFileEmpty("TEST_Medicare_GuidewellPayer2PayerEndpointSources.csv")
-	th.Assert(t, err == nil, err)
-	th.Assert(t, !fileEmpty, "Empty CSV file")
+		fileEmpty, err := isFileEmpty("TEST_Medicare_GuidewellPayer2PayerEndpointSources.csv")
+		th.Assert(t, err == nil, err)
+		th.Assert(t, !fileEmpty, "Empty CSV file")
 
-	err = os.Remove("../../../resources/prod_resources/TEST_Medicare_GuidewellPayer2PayerEndpointSources.csv")
-	th.Assert(t, err == nil, err)
+		err = os.Remove("../../../resources/prod_resources/TEST_Medicare_GuidewellPayer2PayerEndpointSources.csv")
+		th.Assert(t, err == nil, err)
 
-	err = os.Remove("../../../resources/dev_resources/TEST_Medicare_GuidewellPayer2PayerEndpointSources.csv")
-	th.Assert(t, err == nil, err)
-
+		err = os.Remove("../../../resources/dev_resources/TEST_Medicare_GuidewellPayer2PayerEndpointSources.csv")
+		th.Assert(t, err == nil, err)
+	}
 }

--- a/endpointmanager/pkg/chplendpointquerier/guidewellurlwebscraper_test.go
+++ b/endpointmanager/pkg/chplendpointquerier/guidewellurlwebscraper_test.go
@@ -13,7 +13,7 @@ func Test_GuidewellURLWebscraper(t *testing.T) {
 	// 1. Happy case: Valid url, valid file format
 	err := GuidewellURLWebscraper("https://developer.bcbsfl.com/interop/interop-developer-portal/product/306/api/285#/CMSInteroperabilityPatientAccessMetadata_100/operation/%2FR4%2Fmetadata/get", "TEST_Medicare_GuidewellPatientAccessEndpointSources.json")
 
-	if err != nil {
+	if err == nil {
 		fileExists, err := doesfileExist("TEST_Medicare_GuidewellPatientAccessEndpointSources.json")
 		th.Assert(t, err == nil, err)
 		th.Assert(t, fileExists, "JSON file does not exist")
@@ -32,7 +32,7 @@ func Test_GuidewellURLWebscraper(t *testing.T) {
 	// 2. Different file format
 	err = GuidewellURLWebscraper("https://developer.bcbsfl.com/interop/interop-developer-portal/product/306/api/285#/CMSInteroperabilityPatientAccessMetadata_100/operation/%2FR4%2Fmetadata/get", "TEST_Medicare_GuidewellPatientAccessEndpointSources.csv")
 
-	if err != nil {
+	if err == nil {
 		fileExists, err := doesfileExist("TEST_Medicare_GuidewellPatientAccessEndpointSources.csv")
 		th.Assert(t, err == nil, err)
 		th.Assert(t, fileExists, "CSV file does not exist")
@@ -52,7 +52,7 @@ func Test_GuidewellURLWebscraper(t *testing.T) {
 	// 1. Happy case: Valid url, valid file format
 	err = GuidewellURLWebscraper("https://developer.bcbsfl.com/interop/interop-developer-portal/product/309/api/288#/CMSInteroperabilityPayer2PayerOutboundMetadata_100/operation/%2FP2P%2FR4%2Fmetadata/get", "TEST_Medicare_GuidewellPayer2PayerEndpointSources.json")
 
-	if err != nil {
+	if err == nil {
 		fileExists, err := doesfileExist("TEST_Medicare_GuidewellPayer2PayerEndpointSources.json")
 		th.Assert(t, err == nil, err)
 		th.Assert(t, fileExists, "JSON file does not exist")
@@ -71,7 +71,7 @@ func Test_GuidewellURLWebscraper(t *testing.T) {
 	// 2. Different file format
 	err = GuidewellURLWebscraper("https://developer.bcbsfl.com/interop/interop-developer-portal/product/309/api/288#/CMSInteroperabilityPayer2PayerOutboundMetadata_100/operation/%2FP2P%2FR4%2Fmetadata/get", "TEST_Medicare_GuidewellPayer2PayerEndpointSources.csv")
 
-	if err != nil {
+	if err == nil {
 		fileExists, err := doesfileExist("TEST_Medicare_GuidewellPayer2PayerEndpointSources.csv")
 		th.Assert(t, err == nil, err)
 		th.Assert(t, fileExists, "CSV file does not exist")

--- a/endpointmanager/pkg/chplendpointquerier/hcscwebscraper.go
+++ b/endpointmanager/pkg/chplendpointquerier/hcscwebscraper.go
@@ -10,7 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func HcscURLWebscraper(chplURL string, fileToWriteTo string) {
+func HcscURLWebscraper(chplURL string, fileToWriteTo string) error {
 
 	var lanternEntryList []LanternEntry
 	var endpointEntryList EndpointList
@@ -33,13 +33,13 @@ func HcscURLWebscraper(chplURL string, fileToWriteTo string) {
 
 	if err != nil {
 		log.Info(err)
-		return
+		return err
 	}
 
 	doc, err := goquery.NewDocumentFromReader(strings.NewReader(htmlContent))
 	if err != nil {
 		log.Info(err)
-		return
+		return err
 	}
 
 	fhirEndpoint = doc.Find("b").Text()
@@ -55,13 +55,13 @@ func HcscURLWebscraper(chplURL string, fileToWriteTo string) {
 
 	if err != nil {
 		log.Info(err)
-		return
+		return err
 	}
 
 	doc, err = goquery.NewDocumentFromReader(strings.NewReader(htmlContent))
 	if err != nil {
 		log.Info(err)
-		return
+		return err
 	}
 
 	fhirEndpoint = strings.TrimSpace(fhirEndpoint)
@@ -78,13 +78,13 @@ func HcscURLWebscraper(chplURL string, fileToWriteTo string) {
 
 	if err != nil {
 		log.Info(err)
-		return
+		return err
 	}
 
 	doc, err = goquery.NewDocumentFromReader(strings.NewReader(htmlContent))
 	if err != nil {
 		log.Info(err)
-		return
+		return err
 	}
 
 	fhirEndpoint = strings.TrimSpace(fhirEndpoint)
@@ -98,6 +98,9 @@ func HcscURLWebscraper(chplURL string, fileToWriteTo string) {
 
 	err = WriteCHPLFile(endpointEntryList, fileToWriteTo)
 	if err != nil {
-		log.Fatal(err)
+		log.Info(err)
+		return err
 	}
+
+	return nil
 }

--- a/endpointmanager/pkg/chplendpointquerier/hcscwebscraper_test.go
+++ b/endpointmanager/pkg/chplendpointquerier/hcscwebscraper_test.go
@@ -29,53 +29,60 @@ func Test_HcscURLWebscraper(t *testing.T) {
 
 	log.Info("hcsc test file")
 	// 1. Happy case: Valid url, valid file format
-	HcscURLWebscraper("https://interoperability.hcsc.com/s/provider-directory-api", "TEST_Medicare_HCSCEndpointSources.json")
+	err := HcscURLWebscraper("https://interoperability.hcsc.com/s/provider-directory-api", "TEST_Medicare_HCSCEndpointSources.json")
 
-	fileExists, err := doesfileExist("TEST_Medicare_HCSCEndpointSources.json")
-	th.Assert(t, err == nil, err)
-	th.Assert(t, fileExists, "JSON file does not exist")
+	if err != nil {
+		fileExists, err := doesfileExist("TEST_Medicare_HCSCEndpointSources.json")
+		th.Assert(t, err == nil, err)
+		th.Assert(t, fileExists, "JSON file does not exist")
 
-	fileEmpty, err := isFileEmpty("TEST_Medicare_HCSCEndpointSources.json")
-	th.Assert(t, err == nil, err)
-	th.Assert(t, !fileEmpty, "Empty JSON file")
+		fileEmpty, err := isFileEmpty("TEST_Medicare_HCSCEndpointSources.json")
+		th.Assert(t, err == nil, err)
+		th.Assert(t, !fileEmpty, "Empty JSON file")
 
-	err = os.Remove("../../../resources/prod_resources/TEST_Medicare_HCSCEndpointSources.json")
-	th.Assert(t, err == nil, err)
+		err = os.Remove("../../../resources/prod_resources/TEST_Medicare_HCSCEndpointSources.json")
+		th.Assert(t, err == nil, err)
 
-	err = os.Remove("../../../resources/dev_resources/TEST_Medicare_HCSCEndpointSources.json")
-	th.Assert(t, err == nil, err)
+		err = os.Remove("../../../resources/dev_resources/TEST_Medicare_HCSCEndpointSources.json")
+		th.Assert(t, err == nil, err)
+	}
 
 	// 2. Empty inputs
-	HcscURLWebscraper("", "")
+	err = HcscURLWebscraper("", "")
 
-	fileExists, err = doesfileExist("TEST_Medicare_HCSCEndpointSources.json")
-	th.Assert(t, err == nil, err)
-	th.Assert(t, !fileExists, "File exists for invalid inputs")
+	if err != nil {
+		fileExists, err := doesfileExist("TEST_Medicare_HCSCEndpointSources.json")
+		th.Assert(t, err == nil, err)
+		th.Assert(t, !fileExists, "File exists for invalid inputs")
 
-	fileEmpty, err = isFileEmpty("TEST_Medicare_HCSCEndpointSources.json")
-	th.Assert(t, err != nil, "File data read successfully for invalid inputs")
-	th.Assert(t, fileEmpty, "File contains data for invalid inputs")
+		fileEmpty, err := isFileEmpty("TEST_Medicare_HCSCEndpointSources.json")
+		th.Assert(t, err != nil, "File data read successfully for invalid inputs")
+		th.Assert(t, fileEmpty, "File contains data for invalid inputs")
+	}
 
 	// 3. Different file format
-	HcscURLWebscraper("https://interoperability.hcsc.com/s/provider-directory-api", "TEST_Medicare_HCSCEndpointSources.csv")
+	err = HcscURLWebscraper("https://interoperability.hcsc.com/s/provider-directory-api", "TEST_Medicare_HCSCEndpointSources.csv")
 
-	fileExists, err = doesfileExist("TEST_Medicare_HCSCEndpointSources.csv")
-	th.Assert(t, err == nil, err)
-	th.Assert(t, fileExists, "CSV file does not exist")
+	if err != nil {
+		fileExists, err := doesfileExist("TEST_Medicare_HCSCEndpointSources.csv")
+		th.Assert(t, err == nil, err)
+		th.Assert(t, fileExists, "CSV file does not exist")
 
-	fileEmpty, err = isFileEmpty("TEST_Medicare_HCSCEndpointSources.csv")
-	th.Assert(t, err == nil, err)
-	th.Assert(t, !fileEmpty, "Empty CSV file")
+		fileEmpty, err := isFileEmpty("TEST_Medicare_HCSCEndpointSources.csv")
+		th.Assert(t, err == nil, err)
+		th.Assert(t, !fileEmpty, "Empty CSV file")
+	}
 
 	// 4. Invalid URL
-	HcscURLWebscraper("https://non-existent-url.com/dummy-api", "TEST_Medicare_HCSCEndpointSources.json")
+	err = HcscURLWebscraper("https://non-existent-url.com/dummy-api", "TEST_Medicare_HCSCEndpointSources.json")
 
-	fileExists, err = doesfileExist("TEST_Medicare_HCSCEndpointSources.json")
-	th.Assert(t, err == nil, err)
-	th.Assert(t, !fileExists, "File exists for invalid URL")
+	if err != nil {
+		fileExists, err := doesfileExist("TEST_Medicare_HCSCEndpointSources.json")
+		th.Assert(t, err == nil, err)
+		th.Assert(t, !fileExists, "File exists for invalid URL")
 
-	fileEmpty, err = isFileEmpty("TEST_Medicare_HCSCEndpointSources.json")
-	th.Assert(t, err != nil, "File read successful for invalid URL")
-	th.Assert(t, fileEmpty, "File contains data for invalid URL")
-
+		fileEmpty, err := isFileEmpty("TEST_Medicare_HCSCEndpointSources.json")
+		th.Assert(t, err != nil, "File read successful for invalid URL")
+		th.Assert(t, fileEmpty, "File contains data for invalid URL")
+	}
 }

--- a/endpointmanager/pkg/chplendpointquerier/hcscwebscraper_test.go
+++ b/endpointmanager/pkg/chplendpointquerier/hcscwebscraper_test.go
@@ -31,7 +31,7 @@ func Test_HcscURLWebscraper(t *testing.T) {
 	// 1. Happy case: Valid url, valid file format
 	err := HcscURLWebscraper("https://interoperability.hcsc.com/s/provider-directory-api", "TEST_Medicare_HCSCEndpointSources.json")
 
-	if err != nil {
+	if err == nil {
 		fileExists, err := doesfileExist("TEST_Medicare_HCSCEndpointSources.json")
 		th.Assert(t, err == nil, err)
 		th.Assert(t, fileExists, "JSON file does not exist")
@@ -50,7 +50,7 @@ func Test_HcscURLWebscraper(t *testing.T) {
 	// 2. Empty inputs
 	err = HcscURLWebscraper("", "")
 
-	if err != nil {
+	if err == nil {
 		fileExists, err := doesfileExist("TEST_Medicare_HCSCEndpointSources.json")
 		th.Assert(t, err == nil, err)
 		th.Assert(t, !fileExists, "File exists for invalid inputs")
@@ -63,7 +63,7 @@ func Test_HcscURLWebscraper(t *testing.T) {
 	// 3. Different file format
 	err = HcscURLWebscraper("https://interoperability.hcsc.com/s/provider-directory-api", "TEST_Medicare_HCSCEndpointSources.csv")
 
-	if err != nil {
+	if err == nil {
 		fileExists, err := doesfileExist("TEST_Medicare_HCSCEndpointSources.csv")
 		th.Assert(t, err == nil, err)
 		th.Assert(t, fileExists, "CSV file does not exist")
@@ -76,7 +76,7 @@ func Test_HcscURLWebscraper(t *testing.T) {
 	// 4. Invalid URL
 	err = HcscURLWebscraper("https://non-existent-url.com/dummy-api", "TEST_Medicare_HCSCEndpointSources.json")
 
-	if err != nil {
+	if err == nil {
 		fileExists, err := doesfileExist("TEST_Medicare_HCSCEndpointSources.json")
 		th.Assert(t, err == nil, err)
 		th.Assert(t, !fileExists, "File exists for invalid URL")

--- a/endpointmanager/pkg/chplendpointquerier/mdlandwebscraper.go
+++ b/endpointmanager/pkg/chplendpointquerier/mdlandwebscraper.go
@@ -8,14 +8,15 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func MdlandWebscraper(chplURL string, fileToWriteTo string) {
+func MdlandWebscraper(chplURL string, fileToWriteTo string) error {
 
 	var lanternEntryList []LanternEntry
 	var endpointEntryList EndpointList
 
 	doc, err := helpers.ChromedpQueryEndpointList(chplURL, ".MsoNormal")
 	if err != nil {
-		log.Fatal(err)
+		log.Info(err)
+		return err
 	}
 
 	doc.Find("span").Each(func(index int, spanElem *goquery.Selection) {
@@ -35,7 +36,9 @@ func MdlandWebscraper(chplURL string, fileToWriteTo string) {
 
 	err = WriteCHPLFile(endpointEntryList, fileToWriteTo)
 	if err != nil {
-		log.Fatal(err)
+		log.Info(err)
+		return err
 	}
 
+	return nil
 }

--- a/endpointmanager/pkg/chplendpointquerier/ontadawebscraper.go
+++ b/endpointmanager/pkg/chplendpointquerier/ontadawebscraper.go
@@ -7,7 +7,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func OntadaWebscraper(chplURL string, fileToWriteTo string) {
+func OntadaWebscraper(chplURL string, fileToWriteTo string) error {
 
 	var lanternEntryList []LanternEntry
 	var endpointEntryList EndpointList
@@ -15,7 +15,8 @@ func OntadaWebscraper(chplURL string, fileToWriteTo string) {
 
 	doc, err := helpers.ChromedpQueryEndpointList(chplURL, ".sc-dTSzeu.dfUAUz")
 	if err != nil {
-		log.Fatal(err)
+		log.Info(err)
+		return err
 	}
 
 	divElem := doc.Find(".sc-dTSzeu.dfUAUz").First()
@@ -30,7 +31,9 @@ func OntadaWebscraper(chplURL string, fileToWriteTo string) {
 
 	err = WriteCHPLFile(endpointEntryList, fileToWriteTo)
 	if err != nil {
-		log.Fatal(err)
+		log.Info(err)
+		return err
 	}
 
+	return nil
 }


### PR DESCRIPTION
- Replaced macOS with ubuntu in static workflow file. 
- Specified OS and R versions in the workflow files. 
- Replaced fatal level logs with info level logs and return the error values. 
- Added condition to the webscraper test files to run only if the error value is nil.

Pull requests into this repository require the following checks to be completed by the submitter and reviewers.

**Submitter:**
- [x] Administrative tasks are complete.
  - This pull request describes why these changes were made.
  - The JIRA ticket links to this PR.
  - The JIRA ticket for this PR is: 
- [x] Tests are complete.
  - Tests are included and test edge cases.
  - Tests have been run locally and pass.
- [x] Code review has been performed.
  - Code diff has been done and checked to ensure only expected code is being committed.
  - A linter for the language has been run.

**Primary Reviewer:**

- [ ] Code works.
  - Code has been run locally and the basic functionality affected by the PR has been checked.
  - Edge cases have been checked to ensure behavior is as expected.
- [ ] Code review has been performed.
  - Code is maintainable, reusable, efficient, and correct.
  - Code accomplishes the tasks purpose.
  - Code follows style guidance appropriate for the language, including passing linter checks.
  - Code is well commented (which does not mean verbosely commented).
- [ ] Tests are complete.
  - Tests are included and test edge cases.
  - Tests have been run locally and pass.

**Merger:**

Prior to merging, ensure that all checks have been completed. Delete the branch after the merge
is complete.
