### PR TITLE
LANTERN-894: Fix endpoint modal errors

### DIFF
--- a/shinydashboard/lantern/modules/organizationsmodule.R
+++ b/shinydashboard/lantern/modules/organizationsmodule.R
@@ -46,7 +46,7 @@ organizationsmodule <- function(
 
       # Format URL for HTML display with modal popup
       res <- res %>%
-        mutate(url = paste0("<a class=\"lantern-url\" tabindex=\"0\" aria-label=\"Press enter to open a pop up modal containing additional information for this endpoint.\" onkeydown = \"javascript:(function(event) { if (event.keyCode === 13){event.target.click()}})(event)\" onclick=\"Shiny.setInputValue(\'endpoint_popup\',&quot;", url, "&&", fhir_version, "&quot,{priority: \'event\'});\">", url, "</a>"))
+        mutate(url = paste0("<a class=\"lantern-url\" tabindex=\"0\" aria-label=\"Press enter to open a pop up modal containing additional information for this endpoint.\" onkeydown = \"javascript:(function(event) { if (event.keyCode === 13){event.target.click()}})(event)\" onclick=\"Shiny.setInputValue(\'endpoint_popup\',&quot;", url, "&quot,{priority: \'event\'});\">", url, "</a>"))
       
       res <- res %>%
         mutate(organization_id = paste0("<a class=\"lantern-url\" tabindex=\"0\" aria-label=\"Press enter to open a pop up modal containing additional information for this organization.\" onkeydown = \"javascript:(function(event) { if (event.keyCode === 13){event.target.click()}})(event)\" onclick=\"Shiny.setInputValue(\'show_organization_modal\',&quot;", organization_id, "&quot,{priority: \'event\'});\"> HTI-1 Data </a>"))

--- a/shinydashboard/lantern/server.R
+++ b/shinydashboard/lantern/server.R
@@ -831,10 +831,30 @@ observeEvent(input$show_organization_modal, {
 
 # Current Endpoint that is selected to view in Modal
 current_endpoint <- reactive({
-  splitString <- strsplit(input$endpoint_popup, "&&")
-  endpointURL <- splitString[[1]][1]
-  endpoint_requested_fhir_version <- splitString[[1]][2]
+  req(input$endpoint_popup)
 
+  # Check if both URL and version are provided (from Endpoints tab)
+  if (grepl("&&", input$endpoint_popup)) {
+    splitString <- strsplit(input$endpoint_popup, "&&")[[1]]
+    endpointURL <- splitString[1]
+    endpoint_requested_fhir_version <- splitString[2]
+  } else {
+    # Only URL is provided (from Organizations tab)
+    endpointURL <- input$endpoint_popup
+
+    # Query DB for the most recent requested_fhir_version
+    res <- tbl(db_connection, "selected_fhir_endpoints_mv") %>%
+      filter(url == !!endpointURL) %>%
+      arrange(desc(info_updated)) %>%
+      collect()
+
+    if (nrow(res) == 0) {
+      warning(paste("No matching rows found for URL:", endpointURL))
+      endpoint_requested_fhir_version <- NA 
+    } else {
+      endpoint_requested_fhir_version <- res$requested_fhir_version[1]
+    }
+  }
   current_endpoint_list <- list(url = endpointURL, requested_fhir_version = endpoint_requested_fhir_version)
   current_endpoint_list
 })
@@ -1063,14 +1083,21 @@ endpoint_capabilities_page <- function() {
  get_endpoint_list_orgs <- reactive({
     endpoint <- current_endpoint()
 
+    # Get the actual cap_fhir_version using the url only
+    cap_fhir_ver <- get_endpoint_list_matches(db_connection, fhir_version = NULL, vendor = NULL) %>%
+      filter(url == endpoint$url) %>%
+      pull(fhir_version) %>% 
+      unique()
+    
+    # Now use cap_fhir_ver to filter
     res <- get_endpoint_list_matches(db_connection, fhir_version = NULL, vendor = NULL)
     res <- res %>%
-    filter(url == endpoint$url) %>%
-    filter(fhir_version == endpoint$requested_fhir_version) %>%
-    mutate(organization_name = if_else(organization_name == "Unknown", "Not Available", organization_name))
+      filter(url == endpoint$url) %>%
+      filter(fhir_version == cap_fhir_ver) %>%
+      mutate(organization_name = if_else(organization_name == "Unknown", "Not Available", organization_name))
+
     res
   })
-
 
   output$endpoint_list_org_table <- DT::renderDataTable({
     datatable(get_endpoint_list_orgs() %>% distinct(organization_name),
@@ -1110,7 +1137,7 @@ response_time_xts <- reactive({
   res <- get_endpoint_response_time(db_connection, range, endpoint$url, endpoint$requested_fhir_version)
   # convert to xts format for use in dygraph
   xts(x = cbind(res$response),
-      order.by = res$date
+      order.by = res$date 
   )
 })
 


### PR DESCRIPTION
Issue:
	•	When opening the modal from the Organizations tab, only the “Organizations” sub-tab would load data. All other tabs (Details, Capabilities, Implementation Guides & Profiles, Products) were empty.
	•	Conversely, when opening the modal from the Endpoints tab, all tabs would populate correctly except for the “Organizations” sub-tab.

Root Cause:
The modal logic expected an input of the form url&&requested_fhir_version, which the Endpoints tab provided.
The Organizations tab was instead passing url&&fhir_version, resulting in inconsistent behavior and missing data.


Fixes and Updates:
	•	In organizationsmodule.R, updated the modal URL construction to send only the url.
	•	In server.R:
	•	Modified current_endpoint() to support both url&&version and url only formats.
	•	When only the url is available, the logic queries the most recently updated requested_fhir_version from the database.
	•	In get_endpoint_list_orgs(), updated the logic to retrieve the appropriate capability_fhir_version based on the URL for accurate filtering of organization data.

Pull requests into this repository require the following checks to be completed by the submitter and reviewers.

**Submitter:**
- [x] Administrative tasks are complete.
  - This pull request describes why these changes were made.
  - The JIRA ticket links to this PR.
  - The JIRA ticket for this PR is: [LANTERN-894](https://oncprojectracking.healthit.gov/support/browse/LANTERN-894)
- [x] Tests are complete.
  - Tests are included and test edge cases.
  - Tests have been run locally and pass.
- [x] Code review has been performed.
  - Code diff has been done and checked to ensure only expected code is being committed.
  - A linter for the language has been run.

**Primary Reviewer:**

- [x] Code works.
  - Code has been run locally and the basic functionality affected by the PR has been checked.
  - Edge cases have been checked to ensure behavior is as expected.
- [x] Code review has been performed.
  - Code is maintainable, reusable, efficient, and correct.
  - Code accomplishes the tasks purpose.
  - Code follows style guidance appropriate for the language, including passing linter checks.
  - Code is well commented (which does not mean verbosely commented).
- [x] Tests are complete.
  - Tests are included and test edge cases.
  - Tests have been run locally and pass.

**Merger:**

Prior to merging, ensure that all checks have been completed. Delete the branch after the merge
is complete.
