### PR TITLE
Scoped deletions in organizations_map and org table by list_source instead of url

### DIFF
--- a/db/migration/migrations/000076_add_stale_data_cleanup_schema.down.sql
+++ b/db/migration/migrations/000076_add_stale_data_cleanup_schema.down.sql
@@ -4,6 +4,7 @@ ALTER TABLE list_source_info DROP CONSTRAINT IF EXISTS list_source_info_pkey;
 DROP INDEX IF EXISTS idx_list_source_info_updated_at;
 DROP INDEX IF EXISTS idx_fhir_endpoints_metadata_url;
 DROP INDEX IF EXISTS idx_fhir_endpoints_availability_url;
+DROP INDEX IF EXISTS idx_fhir_endpoints_list_source;
 ALTER TABLE list_source_info DROP COLUMN IF EXISTS updated_at;
 
 COMMIT;

--- a/db/migration/migrations/000076_add_stale_data_cleanup_schema.up.sql
+++ b/db/migration/migrations/000076_add_stale_data_cleanup_schema.up.sql
@@ -12,6 +12,7 @@ CREATE INDEX idx_list_source_info_updated_at ON list_source_info(updated_at);
 -- Add missing indexes needed for efficient cleanup operations
 CREATE INDEX idx_fhir_endpoints_metadata_url ON fhir_endpoints_metadata(url);
 CREATE INDEX idx_fhir_endpoints_availability_url ON fhir_endpoints_availability(url);
+CREATE INDEX idx_fhir_endpoints_list_source ON fhir_endpoints(list_source);
 
 -- Add primary key constraint to list_source_info table
 ALTER TABLE list_source_info ADD CONSTRAINT list_source_info_pkey PRIMARY KEY (list_source);

--- a/db/sql/dbsetup.sql
+++ b/db/sql/dbsetup.sql
@@ -463,6 +463,7 @@ CREATE INDEX fhir_endpoint_organizations_npi_id ON fhir_endpoint_organizations (
 --For chpl stale data cleanup
 CREATE INDEX idx_fhir_endpoints_metadata_url ON fhir_endpoints_metadata(url);
 CREATE INDEX idx_fhir_endpoints_availability_url ON fhir_endpoints_availability(url);
+CREATE INDEX idx_fhir_endpoints_list_source ON fhir_endpoints(list_source);
 
 CREATE INDEX vendor_id_idx ON vendors (id);
 CREATE INDEX fhir_endpoints_info_vendor_id_idx ON fhir_endpoints_info (vendor_id);

--- a/endpointmanager/pkg/datacleanup/staledatacleanup.go
+++ b/endpointmanager/pkg/datacleanup/staledatacleanup.go
@@ -113,54 +113,14 @@ func deleteListSourcesBatch(ctx context.Context, tx *sql.Tx, listSources []strin
 func deleteEndpointDataBatch(ctx context.Context, tx *sql.Tx, listSources []string) error {
 	log.Infof("Deleting endpoint data for %d list sources", len(listSources))
 
-	// Step 1: Get all URLs from endpoints to be deleted
-	findEndpointsQuery := `
-		SELECT DISTINCT url FROM fhir_endpoints 
-		WHERE list_source = ANY($1)
-	`
-
-	rows, err := tx.QueryContext(ctx, findEndpointsQuery, pq.Array(listSources))
+	err := deleteBatchEndpointData(ctx, tx, listSources)
 	if err != nil {
-		return fmt.Errorf("failed to find endpoints for list sources: %w", err)
-	}
-	defer rows.Close()
-
-	var endpointURLs []string
-	for rows.Next() {
-		var url string
-		if err := rows.Scan(&url); err != nil {
-			return fmt.Errorf("failed to scan endpoint URL: %w", err)
-		}
-		endpointURLs = append(endpointURLs, url)
+		return fmt.Errorf("failed to delete endpoint data: %w", err)
 	}
 
-	if len(endpointURLs) == 0 {
-		log.Info("No endpoints found for the stale list sources")
-		return nil
-	}
-
-	log.Infof("Found %d unique endpoints to delete", len(endpointURLs))
-
-	// Process URLs in batches to avoid parameter limits
-	batchSize := 1000
-	for i := 0; i < len(endpointURLs); i += batchSize {
-		end := i + batchSize
-		if end > len(endpointURLs) {
-			end = len(endpointURLs)
-		}
-
-		batch := endpointURLs[i:end]
-		log.Infof("Processing batch %d-%d (%d URLs)", i+1, end, len(batch))
-
-		err = deleteBatchEndpointData(ctx, tx, batch)
-		if err != nil {
-			return fmt.Errorf("failed to delete batch %d-%d: %w", i+1, end, err)
-		}
-	}
-
-	// Step 2: Delete from fhir_endpoints (this should be last)
+	// Delete from fhir_endpoints last
 	result, err := tx.ExecContext(ctx, `
-		DELETE FROM fhir_endpoints 
+		DELETE FROM fhir_endpoints
 		WHERE list_source = ANY($1)
 	`, pq.Array(listSources))
 	if err != nil {
@@ -173,21 +133,23 @@ func deleteEndpointDataBatch(ctx context.Context, tx *sql.Tx, listSources []stri
 	return nil
 }
 
-func deleteBatchEndpointData(ctx context.Context, tx *sql.Tx, urls []string) error {
+func deleteBatchEndpointData(ctx context.Context, tx *sql.Tx, listSources []string) error {
 	// Delete in order of foreign key dependencies
 	// REMOVED: fhir_endpoints_info, fhir_endpoints_info_history, fhir_endpoints_availability, fhir_endpoints_metadata
 	// These tables preserve history and metadata and should NOT be deleted
 
-	// 1. Delete from fhir_endpoint_organizations first
+	// 1. Delete from fhir_endpoint_organizations first.
+	// Scoped by list_source (via fhir_endpoints.id) so that org records shared with
+	// a live list source that happens to contain the same URL are not affected.
 	result, err := tx.ExecContext(ctx, `
-		DELETE FROM fhir_endpoint_organizations 
+		DELETE FROM fhir_endpoint_organizations
 		WHERE id IN (
-			SELECT m.org_database_id 
-			FROM fhir_endpoints e, fhir_endpoint_organizations_map m 
-			WHERE e.id = m.id 
-			AND e.url = ANY($1)
+			SELECT m.org_database_id
+			FROM fhir_endpoints e
+			JOIN fhir_endpoint_organizations_map m ON e.id = m.id
+			WHERE e.list_source = ANY($1)
 		)
-	`, pq.Array(urls))
+	`, pq.Array(listSources))
 	if err != nil {
 		log.Errorf("Failed to delete from fhir_endpoint_organizations: %v", err)
 		return err
@@ -198,14 +160,15 @@ func deleteBatchEndpointData(ctx context.Context, tx *sql.Tx, urls []string) err
 		log.Infof("No records to delete from fhir_endpoint_organizations")
 	}
 
-	// 2. Delete from fhir_endpoint_organizations_map
+	// 2. Delete from fhir_endpoint_organizations_map.
+	// Scoped by list_source so entries for the same URL in a live list source are preserved.
 	result, err = tx.ExecContext(ctx, `
-		DELETE FROM fhir_endpoint_organizations_map 
+		DELETE FROM fhir_endpoint_organizations_map
 		WHERE id IN (
-			SELECT id FROM fhir_endpoints 
-			WHERE url = ANY($1)
+			SELECT id FROM fhir_endpoints
+			WHERE list_source = ANY($1)
 		)
-	`, pq.Array(urls))
+	`, pq.Array(listSources))
 	if err != nil {
 		log.Errorf("Failed to delete from fhir_endpoint_organizations_map: %v", err)
 		return err
@@ -216,11 +179,21 @@ func deleteBatchEndpointData(ctx context.Context, tx *sql.Tx, urls []string) err
 		log.Infof("No records to delete from fhir_endpoint_organizations_map")
 	}
 
-	// 3. Delete from endpoint_organization
+	// 3. Delete from endpoint_organization only for URLs that are no longer referenced
+	// by any live list source. If a URL exists in another active list source, keep it.
+	// NOT EXISTS is used instead of NOT IN to correctly handle NULL urls and improve
+	// performance via index on (url, list_source).
 	result, err = tx.ExecContext(ctx, `
-		DELETE FROM endpoint_organization 
-		WHERE url = ANY($1)
-	`, pq.Array(urls))
+		DELETE FROM endpoint_organization
+		WHERE url IN (
+			SELECT url FROM fhir_endpoints WHERE list_source = ANY($1)
+		)
+		AND NOT EXISTS (
+			SELECT 1 FROM fhir_endpoints fe2
+			WHERE fe2.url = endpoint_organization.url
+			AND NOT (fe2.list_source = ANY($1))
+		)
+	`, pq.Array(listSources))
 	if err != nil {
 		log.Errorf("Failed to delete from endpoint_organization: %v", err)
 		return err


### PR DESCRIPTION
Previously, deletions based on URL removed organization records even when they were still associated with active list sources. This change ensures that only stale entries are cleaned up and preserves organizations shared across multiple FHIR endpoints.

Pull requests into this repository require the following checks to be completed by the submitter and reviewers.

**Submitter:**
- [x] Administrative tasks are complete.
  - This pull request describes why these changes were made.
  - The JIRA ticket links to this PR.
  - The JIRA ticket for this PR is: 
- [x] Tests are complete.
  - Tests are included and test edge cases.
  - Tests have been run locally and pass.
- [x] Code review has been performed.
  - Code diff has been done and checked to ensure only expected code is being committed.
  - A linter for the language has been run.

**Primary Reviewer:**

- [ ] Code works.
  - Code has been run locally and the basic functionality affected by the PR has been checked.
  - Edge cases have been checked to ensure behavior is as expected.
- [ ] Code review has been performed.
  - Code is maintainable, reusable, efficient, and correct.
  - Code accomplishes the tasks purpose.
  - Code follows style guidance appropriate for the language, including passing linter checks.
  - Code is well commented (which does not mean verbosely commented).
- [ ] Tests are complete.
  - Tests are included and test edge cases.
  - Tests have been run locally and pass.

**Merger:**

Prior to merging, ensure that all checks have been completed. Delete the branch after the merge
is complete.
